### PR TITLE
feat:CSSの調整

### DIFF
--- a/src/components/service-card.tsx
+++ b/src/components/service-card.tsx
@@ -7,27 +7,34 @@ interface ServiceCardProps {
 
 export function ServiceCard({ id, title, description }: ServiceCardProps) {
   return (
-    <div className="bg-white p-6 rounded-lg shadow-md hover:shadow-lg transition-shadow">
-      <h3 className="text-xl font-bold mb-4">{title}</h3>
-      <p className="text-gray-600 mb-4">{description}</p>
+    <div className="relative bg-white p-6 rounded-2xl group border  shadow-sm hover:shadow-xl transition-shadow duration-200">
       <a
         href={`/services/${id}`} // IDを使用してリンクを生成
-        className="inline-flex items-center text-purple-700 hover:text-purple-900 transition-colors group"
+        className="h-full w-full"
       >
-        VIEW MORE
-        <svg
-          className="h-4 w-4 ml-2 group-hover:translate-x-1 transition-transform"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M17 8l4 4m0 0l-4 4m4-4H3"
-          />
-        </svg>
+        <h3 className="text-xl font-semibold mb-4">{title}</h3>
+        <p className="text-gray-600 mb-4">{description}</p>
+        <div>
+          <p className="absolute bottom-3 right-12 font-Poppins text-transparent group-hover:text-indigo-600 duration-300">
+            view more
+          </p>
+          <div className="absolute bottom-2 right-2 bg-indigo-700 rounded-full size-8 flex justify-center items-center group-hover:rotate-45 duration-200">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="white"
+              className="size-6"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3"
+              />
+            </svg>
+          </div>
+        </div>
       </a>
     </div>
   );

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -27,169 +27,141 @@ import Layout from '../layouts/layout.astro'; // .tsxは不要です
 
 <Layout title="Beekle - 技術を用いて人を幸せに">
   <Header client:load />
-  <main >
-    <section class="pt-32 relative min-h-screen flex items-center justify-center overflow-hidden">
+  <main class="">
+    <section class="overflow-hidden">
       <!-- 動的な背景エフェクト -->
-      <div class="absolute inset-0 bg-gradient-to-br from-purple-600 via-pink-500 to-orange-400">
+      <!-- <div>
         <div class="absolute inset-0 bg-grid-pattern opacity-10"></div>
-        <div class="absolute inset-0 bg-gradient-to-t from-black/30 to-transparent"></div>
-      </div>
-
+      </div> -->
       <!-- 装飾的な要素 -->
-      <div class="absolute top-0 left-0 w-full h-full">
+      <!-- <div class="absolute top-0 left-0 w-full h-full">
         <div class="absolute top-20 left-20 w-64 h-64 bg-purple-500/20 rounded-full blur-3xl animate-pulse"></div>
         <div class="absolute bottom-20 right-20 w-96 h-96 bg-pink-500/20 rounded-full blur-3xl animate-pulse delay-700"></div>
+      </div> -->
+    </section>
+    <!-- メインコンテンツ -->
+    <!-- タイトル -->
+    <section class="h-[calc(100vh-120px)] lg:mx-12 mt-20 xl:p-24 p-12 border border-indigo-700 rounded-[48px] text-indigo-700 flex flex-col justify-center gap-16">
+      <h1 class="text-7xl font-semibold leading-snug">
+        売上を上げる
+        <br>
+        システム開発
+      </h1>
+      <!-- サブタイトル -->
+      <div class="text-xl">
+        <p class="mb-2 font-Poppins text-2xl">Our mission :</p>
+        <p>課題とニーズを深く調査し、最良の施策をご提案します。</p>
       </div>
-
-      <!-- メインコンテンツ -->
-      <div class="container relative mx-auto px-4 text-center py-24">
-        <div class="space-y-8">
-          <!-- タイトル -->
-          <h1 class="relative">
-            <span class="block text-6xl md:text-8xl font-bold text-white mb-4 tracking-tight">
-              技術を用いて
-              <span class="relative inline-block">
-                <span class="relative z-10">人を幸せに</span>
-                <span class="absolute bottom-0 left-0 w-full h-3 bg-purple-400/50 transform -skew-x-12"></span>
-              </span>
-            </span>
-          </h1>
-
-          <!-- サブタイトル -->
-          <p class="text-xl md:text-2xl text-white/90 max-w-3xl mx-auto leading-relaxed backdrop-blur-sm rounded-lg p-4">
-            Beekleは、お客様のビジネスに寄り添った
-            <span class="font-semibold text-purple-200">マーケティング</span>・
-            <span class="font-semibold text-pink-200">情報設計</span>・
-            <span class="font-semibold text-orange-200">デザイン</span>・
-            <span class="font-semibold text-yellow-200">開発</span>
-            等トータルサポートを行います。
-          </p>
-
-          <!-- CTAボタン -->
-          <div class="flex justify-center gap-6 mt-12">
-          <!-- Services Section -->
-          <section id="services" class="py-20 ">
-            <div class="container mx-auto px-4">
-              <h2 class="text-3xl font-bold text-center mb-12 text-white">SERVICE</h2>
-              <div class="grid md:grid-cols-3 gap-8">
-                {services.map((service) => (
-                  <ServiceCard
-                    client:visible
-                    id={service.id}
-                    title={service.title}
-                    description={service.description}
-                  />
-                ))}
-              </div>
-            </div>
-          </section>
-            
-          </div>
-          <section>
-            <a href="contact" class="px-8 py-4 bg-transparent border-2 border-white text-white rounded-full font-bold text-lg hover:bg-white/10 transition-all duration-300">
-              お問い合わせ
-            </a>
-            </section>
+    </section>
+    <!-- Services Section -->
+    <section id="services" class="container mx-auto px-12 py-24">
+        <h2 class="text-5xl font-Poppins text-indigo-700 mb-2">Services :</h2>
+        <p class="text-md mb-6 text-slate-500">
+          Beekleは、お客様のビジネスに寄り添ったマーケティング・情報設計・デザイン・開発等のトータルサポートを行います。
+        </p>
+        <div class="grid md:grid-cols-3 gap-8">
+          {services.map((service) => (
+            <ServiceCard
+              client:visible
+              id={service.id}
+              title={service.title}
+              description={service.description}
+            />
+          ))}
         </div>
-
-
-    
-
-        <!-- スクロールダウンインジケーター -->
-        <div class="absolute bottom-12 left-1/2 transform -translate-x-1/2">
-          <div class="animate-bounce">
-            <svg
-              class="h-12 w-12 text-white/70"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width={2}
-                d="M19 14l-7 7m0 0l-7-7m7 7V3"
-              />
-            </svg>
-          </div>
-        </div>
+    </section>
+    <div class="text-center">
+      <a href="contact" class="px-8 py-4 border border-indigo-700 text-indigo-700 rounded-full font-normal text-lg hover:px-12 hover:py-6 hover:bg-indigo-100/20 transition-all duration-100">
+        お問い合わせはこちら
+      </a>
+    </div>
+    <!-- スクロールダウンインジケーター -->
+    <div class="absolute bottom-12 left-1/2 transform -translate-x-1/2">
+      <div class="animate-bounce">
+        <svg
+          class="h-12 w-12 text-indigo-700/50"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width={1}
+            d="M19 14l-7 7m0 0l-7-7m7 7V3"
+          />
+        </svg>
       </div>
-
-      
-      
-
+    </div>
       <!-- 装飾的な浮遊要素 -->
-      <div class="absolute inset-0 pointer-events-none">
+      <!-- <div class="absolute inset-0 pointer-events-none">
         <div class="absolute top-1/4 left-1/4 w-2 h-2 bg-white rounded-full animate-float"></div>
         <div class="absolute top-3/4 right-1/4 w-3 h-3 bg-purple-300 rounded-full animate-float-delay"></div>
         <div class="absolute bottom-1/4 left-1/3 w-2 h-2 bg-pink-300 rounded-full animate-float-slow"></div>
-      </div>
-    </section>
-
+      </div> -->
 
     <!-- FAQプレビューセクション -->
-<section class="mt-16 py-24 bg-gray-50">
-  <div class="container mx-auto px-4">
-    <h2 class="text-4xl font-bold text-center mb-4">よくあるお悩み</h2>
-    <p class="text-gray-600 text-center mb-16 text-lg">お客様からよくいただくご相談をまとめました</p>
-    
-    <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto mb-12">
-      <!-- 代表的な質問を4つ程度表示 -->
-      <div class="bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-shadow">
-        <h4 class="font-bold text-gray-800 flex items-center mb-3">
-          <span class="text-purple-600 mr-2">Q.</span>
-          システム開発の予算が見えづらい
-        </h4>
-        <p class="text-gray-600 ml-6">
-          要件定義フェーズでの綿密な計画立案と、アジャイル開発による段階的な開発により、予算の透明性を確保します。
-        </p>
-      </div>
+  <section class="mt-16 py-24 bg-slate-50">
+    <div class="container mx-auto px-4">
+      <h2 class="text-4xl font-bold text-center mb-4">よくあるお悩み</h2>
+      <p class="text-gray-600 text-center mb-16 text-lg">お客様からよくいただくご相談をまとめました</p>
       
-      <div class="bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-shadow">
-        <h4 class="font-bold text-gray-800 flex items-center mb-3">
-          <span class="text-purple-600 mr-2">Q.</span>
-          最適な技術スタックが分からない
-        </h4>
-        <p class="text-gray-600 ml-6">
-          プロジェクトの規模、予算、期間、将来の拡張性を考慮し、実績のある技術スタックを提案いたします。
-        </p>
+      <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto mb-12">
+        <!-- 代表的な質問を4つ程度表示 -->
+        <div class="bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-shadow">
+          <h4 class="font-bold text-gray-800 flex items-center mb-3">
+            <span class="font-Poppins text-indigo-600 mr-2 font-normal">Q.</span>
+            システム開発の予算が見えづらい
+          </h4>
+          <p class="text-gray-600 ml-6">
+            要件定義フェーズでの綿密な計画立案と、アジャイル開発による段階的な開発により、予算の透明性を確保します。
+          </p>
+        </div>
+        
+        <div class="bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-shadow">
+          <h4 class="font-bold text-gray-800 flex items-center mb-3">
+            <span class="font-Poppins text-indigo-600 mr-2 font-normal">Q.</span>
+            最適な技術スタックが分からない
+          </h4>
+          <p class="text-gray-600 ml-6">
+            プロジェクトの規模、予算、期間、将来の拡張性を考慮し、実績のある技術スタックを提案いたします。
+          </p>
+        </div>
+
+        <div class="bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-shadow">
+          <h4 class="font-bold text-gray-800 flex items-center mb-3">
+            <span class="font-Poppins text-indigo-600 mr-2 font-normal">Q.</span>
+            システムの安定性に不安がある
+          </h4>
+          <p class="text-gray-600 ml-6">
+            24時間365日のモニタリング体制と、自動化された障害検知システムにより、問題の早期発見・対応が可能です。
+          </p>
+        </div>
+
+        <div class="bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-shadow">
+          <h4 class="font-bold text-gray-800 flex items-center mb-3">
+            <span class="font-Poppins text-indigo-600 mr-2 font-normal">Q.</span>
+            保守・運用コストが高騰している
+          </h4>
+          <p class="text-gray-600 ml-6">
+            自動化ツールの導入や運用プロセスの最適化により、保守コストを削減。クラウドの特性を活かした柔軟なリソース管理を実現します。
+          </p>
+        </div>
       </div>
 
-      <div class="bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-shadow">
-        <h4 class="font-bold text-gray-800 flex items-center mb-3">
-          <span class="text-purple-600 mr-2">Q.</span>
-          システムの安定性に不安がある
-        </h4>
-        <p class="text-gray-600 ml-6">
-          24時間365日のモニタリング体制と、自動化された障害検知システムにより、問題の早期発見・対応が可能です。
-        </p>
-      </div>
-
-      <div class="bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-shadow">
-        <h4 class="font-bold text-gray-800 flex items-center mb-3">
-          <span class="text-purple-600 mr-2">Q.</span>
-          保守・運用コストが高騰している
-        </h4>
-        <p class="text-gray-600 ml-6">
-          自動化ツールの導入や運用プロセスの最適化により、保守コストを削減。クラウドの特性を活かした柔軟なリソース管理を実現します。
-        </p>
+      <div class="mt16 text-center">
+        <a
+          href="/knowledge"
+          class="inline-flex items-center justify-center px-8 py-4 text-lg font-medium text-indigo-700 border border-indigo-600 rounded-full hover:bg-indigo-100 transition-all"
+        >
+          よくあるお悩みをもっと見る
+          <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+          </svg>
+        </a>
       </div>
     </div>
-
-    <div class="mt16 text-center">
-      <a
-        href="/knowledge"
-        class="inline-flex items-center justify-center px-8 py-4 text-lg font-medium text-purple-600 border-2 border-purple-600 rounded-full hover:bg-purple-50 transition-all"
-      >
-        よくあるお悩みをもっと見る
-        <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
-        </svg>
-      </a>
-    </div>
-  </div>
-</section>
-
+  </section>
     <!-- 他のセクション... -->
   </main>
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,7 +1,12 @@
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 @layer base {
+  html {
+    font-family: Poppins, Noto Sans JP, ;
+  }
   :root {
     --background: 0 0% 100%;
     --foreground: 222.2 84% 4.9%;

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -52,6 +52,10 @@ export default {
         },
       },
     },
+    fontFamily: {
+        Poppins: ['Poppins', 'sans-serif'],
+        NotoSansJP: ['Noto Sans JP', 'sans-serif'],
+    },
   },
   plugins: [require('tailwindcss-animate')],
 };


### PR DESCRIPTION
## 概要
- GoogleFontのimport
- TOPページの調整

## やったこと
Noto Sans JP
Poppins
の2種類のGoogle Font を global.css にimport

HTML構造を変更
→ sectionの中にsectionが入っていたりしていたので、ちょっとだけ整えました。（まだ整理は必要かも）

Hero image部分のデザインを変更
serviceセクションのデザインを変更
service-cardのデザインを変更

![Screenshot 2024-12-30 at 20 19 41](https://github.com/user-attachments/assets/10202d22-537c-456b-a80a-b2780bcb40a3)
![Screenshot 2024-12-30 at 20 19 50](https://github.com/user-attachments/assets/10590a42-9443-4d98-9071-cbcdbef73d4c)

## 確認事項
ボタンのCSSも一旦変更していますが、CTAボタンの配置やサイズ、他のボタンと合わせてコンポーネント化は要検討かなと思います。
