### PR TITLE
feat: Strength 04 シナリオ設計力セクション実装

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -23,6 +23,9 @@ const cardVariants = cva('relative overflow-hidden transition-all duration-300',
       // ライトパープル背景
       lightPurple: 'bg-gradient-to-br from-primary-50 via-white to-primary-50/30 rounded-[32px]',
 
+      // ライトシアン背景
+      lightCyan: 'bg-gradient-to-br from-secondary-50 via-white to-secondary-50/30 rounded-[32px]',
+
       // プライマリ背景: Beekle Purple
       primary: 'bg-primary-500 text-white rounded-[32px]',
 
@@ -47,6 +50,9 @@ const cardVariants = cva('relative overflow-hidden transition-all duration-300',
 
       // アウトライン（プライマリ）
       outlinedPrimary: 'bg-white rounded-[32px] border-2 border-primary-500',
+
+      // アウトライン（セカンダリ）
+      outlinedSecondary: 'bg-white rounded-[32px] border-2 border-secondary-500',
 
       // ガラス効果
       glass: 'bg-white/80 backdrop-blur-sm border border-white/20 rounded-[32px]',

--- a/src/components/ui/page-hero.tsx
+++ b/src/components/ui/page-hero.tsx
@@ -1,44 +1,24 @@
 import type { ReactNode } from 'react';
 
 interface PageHeroProps {
-  /** 大きな英字テキスト（例: "STRENGTHS", "WORKS"） */
-  englishTitle: string;
   /** 日本語タイトル（h1） */
   title: string | ReactNode;
   /** サブタイトル/説明文（オプション） */
   subtitle?: string;
-  /** デコレーションの種類 */
-  decoration?: 'fullDark' | 'barsDark' | 'none';
   /** バッジテキスト（オプション） */
   badge?: string;
   /** 追加コンテンツ（CTAボタンなど） */
   children?: ReactNode;
 }
 
-export function PageHero({
-  englishTitle,
-  title,
-  subtitle,
-  decoration = 'fullDark',
-  badge,
-  children,
-}: PageHeroProps) {
-  const decorationClasses = {
-    fullDark: 'before:absolute before:inset-0 before:bg-grid-pattern before:opacity-10',
-    barsDark: 'before:absolute before:inset-0 before:bg-grid-pattern before:opacity-10',
-    none: '',
-  };
-
+export function PageHero({ title, subtitle, badge, children }: PageHeroProps) {
   return (
-    <section
-      className={`relative py-24 md:py-32 bg-primary-500 overflow-hidden ${decorationClasses[decoration]}`}
-    >
-      {/* Floating decorations */}
-      <div className="absolute top-10 right-10 w-24 h-24 bg-white/10 rounded-full blur-2xl" />
-      <div className="absolute bottom-10 left-20 w-32 h-32 bg-white/10 rounded-full blur-2xl" />
+    <section className="relative bg-primary-500 py-20 overflow-hidden">
+      {/* Grid pattern decoration */}
+      <div className="absolute inset-0 bg-grid-pattern opacity-10" />
 
-      <div className="container mx-auto px-6 md:px-8 relative">
-        <div className="text-center max-w-4xl mx-auto">
+      <div className="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl relative">
+        <div className="text-center">
           {/* バッジ */}
           {badge && (
             <div className="inline-block mb-6">
@@ -48,23 +28,16 @@ export function PageHero({
             </div>
           )}
 
-          {/* 英字タイトル */}
-          <span className="font-Poppins text-7xl md:text-8xl lg:text-9xl font-bold text-white/20 block mb-4 select-none">
-            {englishTitle}
-          </span>
-
-          {/* 日本語タイトル - デザイントークン typography.heading.h1 準拠 */}
-          <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">{title}</h1>
+          {/* タイトル */}
+          <h1 className="text-4xl font-bold text-white sm:text-5xl mb-6">{title}</h1>
 
           {/* サブタイトル */}
           {subtitle && (
-            <p className="text-lg md:text-xl text-white/90 max-w-3xl mx-auto leading-relaxed mb-8">
-              {subtitle}
-            </p>
+            <p className="text-xl text-white/90 max-w-3xl mx-auto leading-relaxed">{subtitle}</p>
           )}
 
           {/* 追加コンテンツ（CTAボタンなど） */}
-          {children}
+          {children && <div className="mt-8">{children}</div>}
         </div>
       </div>
     </section>

--- a/src/lib/microcms.ts
+++ b/src/lib/microcms.ts
@@ -1,4 +1,4 @@
-import { createClient, type MicroCMSClient } from 'microcms-js-sdk';
+import { type MicroCMSClient, createClient } from 'microcms-js-sdk';
 
 // MicroCMS APIクライアント（遅延初期化）
 let _client: MicroCMSClient | null = null;

--- a/src/pages/case-studies.astro
+++ b/src/pages/case-studies.astro
@@ -1,5 +1,6 @@
 ---
 import { Header } from '../components/header';
+import { PageHero } from '../components/ui/page-hero';
 // src/pages/case-studies.astro
 import Layout from '../layouts/layout.astro';
 
@@ -221,16 +222,10 @@ const cases = [
 <Layout title="導入事例 | Beekle">
   <Header client:load />
   <main class="pt-20">
-    <section class="bg-primary-500 py-20">
-      <div class="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl text-center">
-        <h1 class="text-4xl font-bold text-white sm:text-5xl mb-6">
-          導入事例
-        </h1>
-        <p class="text-xl text-white/90 max-w-3xl mx-auto">
-          お客様の課題解決と事業成長をサポートした実績をご紹介します
-        </p>
-      </div>
-    </section>
+    <PageHero
+      title="導入事例"
+      subtitle="お客様の課題解決と事業成長をサポートした実績をご紹介します"
+    />
 
     <section class="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl py-16">
 

--- a/src/pages/column.astro
+++ b/src/pages/column.astro
@@ -41,7 +41,6 @@ const totalArticles = columnCategories.reduce((sum, cat) => sum + cat.articles.l
   <main class="pt-20">
     {/* Hero Section */}
     <PageHero
-      englishTitle="COLUMN"
       title="コラムで学ぶ システム開発の知識"
       subtitle="「開発って、正直よくわからない」という不安を解消。失敗しないための実践的な知識を、体系的にお届けします。"
       badge="Knowledge Base"

--- a/src/pages/company.astro
+++ b/src/pages/company.astro
@@ -37,7 +37,6 @@ const companyInfo = {
   <main class="pt-20">
     <!-- Hero Section -->
     <PageHero
-      englishTitle="COMPANY"
       title="会社概要"
       subtitle="BeekleはWebアプリ、モバイルアプリやシステム開発の受託をしている制作チームです。20名程度の小規模ながら、デザイナーからマーケター、プログラマーと様々な人が所属しており、幅広い案件を担当することが可能です。"
     />

--- a/src/pages/company.astro
+++ b/src/pages/company.astro
@@ -1,33 +1,33 @@
 ---
 // src/pages/company.astro
 
-import Layout from '@/layouts/layout.astro';
-import { Header } from '../components/header';
-import { PageHero } from '../components/ui/page-hero';
+import Layout from "@/layouts/layout.astro";
+import { Header } from "../components/header";
+import { PageHero } from "../components/ui/page-hero";
 
 const companyInfo = {
-  name: '株式会社Beekle',
-  established: '2023年2月1日',
-  capital: '100万円',
-  ceo: '鶴岡邦夫',
-  address: '東京都大田区久が原３丁目１４番２７号',
-  email: 'support@beekle.jp',
-  holiday: '土曜日、日曜日、祝日',
+  name: "株式会社Beekle",
+  established: "2023年2月1日",
+  capital: "100万円",
+  ceo: "鶴岡邦夫",
+  address: "東京都大田区久が原３丁目１４番２７号",
+  email: "support@beekle.jp",
+  holiday: "土曜日、日曜日、祝日",
   advisors: {
-    tax: '檜山税理士事務所',
-    legal: '猿渡法律事務所',
-    tech: '中村有貴',
-    labor: '笠原労務管理事務所',
+    tax: "檜山税理士事務所",
+    legal: "猿渡法律事務所",
+    tech: "中村有貴",
+    labor: "笠原労務管理事務所",
   },
   business: [
-    'コンピュータのソフトウェア・ハードウェアの企画、研究、開発、設計、製造、販売、保守、リース、賃貸、輸出入',
-    'インターネット等を利用した各種情報提供サービス',
-    '通信販売事業',
-    '各種業務に関するアウトソーシングの受託',
-    '人材育成・能力開発のための研修、教育',
-    'マーケティングに関する企画、調査',
-    'コンサルティング業務',
-    '前各号に附帯関連する一切の事業',
+    "コンピュータのソフトウェア・ハードウェアの企画、研究、開発、設計、製造、販売、保守、リース、賃貸、輸出入",
+    "インターネット等を利用した各種情報提供サービス",
+    "通信販売事業",
+    "各種業務に関するアウトソーシングの受託",
+    "人材育成・能力開発のための研修、教育",
+    "マーケティングに関する企画、調査",
+    "コンサルティング業務",
+    "前各号に附帯関連する一切の事業",
   ],
 };
 ---
@@ -38,7 +38,7 @@ const companyInfo = {
     <!-- Hero Section -->
     <PageHero
       title="会社概要"
-      subtitle="BeekleはWebアプリ、モバイルアプリやシステム開発の受託をしている制作チームです。20名程度の小規模ながら、デザイナーからマーケター、プログラマーと様々な人が所属しており、幅広い案件を担当することが可能です。"
+      subtitle="BeekleはWebアプリ、モバイルアプリやシステム開発の受託をしている制作チームです。小規模ながら、デザイナーからマーケター、プログラマーと様々な人が所属しており、幅広い案件を担当することが可能です。"
     />
 
     <!-- About Section -->
@@ -99,20 +99,22 @@ const companyInfo = {
           <h2 class="text-3xl font-bold text-center mb-16">会社概要</h2>
           <div class="bg-white rounded-xl shadow-lg overflow-hidden">
             <div class="divide-y divide-gray-200">
-              {Object.entries({
-                会社名: companyInfo.name,
-                設立: companyInfo.established,
-                資本金: companyInfo.capital,
-                代表取締役: companyInfo.ceo,
-                所在地: companyInfo.address,
-                メールアドレス: companyInfo.email,
-                休日: companyInfo.holiday,
-              }).map(([key, value]) => (
-                <div class="flex py-4 px-6">
-                  <dt class="w-40 font-bold text-gray-700">{key}</dt>
-                  <dd class="flex-1 text-gray-600">{value}</dd>
-                </div>
-              ))}
+              {
+                Object.entries({
+                  会社名: companyInfo.name,
+                  設立: companyInfo.established,
+                  資本金: companyInfo.capital,
+                  代表取締役: companyInfo.ceo,
+                  所在地: companyInfo.address,
+                  メールアドレス: companyInfo.email,
+                  休日: companyInfo.holiday,
+                }).map(([key, value]) => (
+                  <div class="flex py-4 px-6">
+                    <dt class="w-40 font-bold text-gray-700">{key}</dt>
+                    <dd class="flex-1 text-gray-600">{value}</dd>
+                  </div>
+                ))
+              }
             </div>
           </div>
 
@@ -120,9 +122,11 @@ const companyInfo = {
           <div class="mt-12 bg-white rounded-xl shadow-lg p-8">
             <h3 class="text-xl font-bold text-gray-800 mb-6">事業内容</h3>
             <ol class="list-decimal list-inside space-y-4 text-gray-600">
-              {companyInfo.business.map(item => (
-                <li class="leading-relaxed">{item}</li>
-              ))}
+              {
+                companyInfo.business.map((item) => (
+                  <li class="leading-relaxed">{item}</li>
+                ))
+              }
             </ol>
           </div>
 
@@ -130,16 +134,22 @@ const companyInfo = {
           <div class="mt-12 bg-white rounded-xl shadow-lg p-8">
             <h3 class="text-xl font-bold text-gray-800 mb-6">顧問</h3>
             <div class="grid md:grid-cols-2 gap-6">
-              {Object.entries(companyInfo.advisors).map(([type, name]) => (
-                <div class="flex items-center">
-                  <dt class="w-40 font-bold text-gray-700">
-                    {type === 'tax' ? '税理士' : 
-                     type === 'legal' ? '弁護士' :
-                     type === 'tech' ? '技術顧問' : '労務顧問'}
-                  </dt>
-                  <dd class="flex-1 text-gray-600">{name}</dd>
-                </div>
-              ))}
+              {
+                Object.entries(companyInfo.advisors).map(([type, name]) => (
+                  <div class="flex items-center">
+                    <dt class="w-40 font-bold text-gray-700">
+                      {type === "tax"
+                        ? "税理士"
+                        : type === "legal"
+                          ? "弁護士"
+                          : type === "tech"
+                            ? "技術顧問"
+                            : "労務顧問"}
+                    </dt>
+                    <dd class="flex-1 text-gray-600">{name}</dd>
+                  </div>
+                ))
+              }
             </div>
           </div>
         </div>
@@ -150,7 +160,8 @@ const companyInfo = {
 
 <style>
   .bg-grid-pattern {
-    background-image: linear-gradient(rgba(255, 255, 255, 0.1) 1px, transparent 1px),
+    background-image:
+      linear-gradient(rgba(255, 255, 255, 0.1) 1px, transparent 1px),
       linear-gradient(90deg, rgba(255, 255, 255, 0.1) 1px, transparent 1px);
     background-size: 20px 20px;
   }

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -10,7 +10,6 @@ import Layout from '../layouts/layout.astro';
   <main class="pt-20">
     <!-- Hero Section -->
     <PageHero
-      englishTitle="CONTACT"
       title="お問い合わせ"
       subtitle="プロジェクトについてのご相談やお見積もりのご依頼など、お気軽にお問い合わせください。"
     />

--- a/src/pages/development-issues.astro
+++ b/src/pages/development-issues.astro
@@ -1,23 +1,17 @@
 ---
 import { DevelopmentIssuesList } from '../components/development-issues-list';
 import { Header } from '../components/header';
+import { PageHero } from '../components/ui/page-hero';
 import Layout from '../layouts/layout.astro';
 ---
 
 <Layout title="システム開発問題ケーススタディ | Beekle">
   <Header client:load />
   <main class="pt-20">
-    <section class="bg-primary-500 py-20">
-      <div class="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl text-center">
-        <h1 class="text-4xl font-bold text-white sm:text-5xl mb-6">
-          システム開発問題ケーススタディ
-        </h1>
-        <p class="text-xl text-white/90 max-w-3xl mx-auto">
-          システム開発で直面する様々な課題と、その解決アプローチをご紹介します。<br />
-          プロジェクトの失敗から学び、成功への道筋を見つけ出した実例をご覧ください。
-        </p>
-      </div>
-    </section>
+    <PageHero
+      title="システム開発問題ケーススタディ"
+      subtitle="システム開発で直面する様々な課題と、その解決アプローチをご紹介します。プロジェクトの失敗から学び、成功への道筋を見つけ出した実例をご覧ください。"
+    />
 
     <section class="bg-gray-50 py-16">
       <div class="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl">

--- a/src/pages/knowledge.astro
+++ b/src/pages/knowledge.astro
@@ -1,5 +1,6 @@
 ---
 import { Header } from '../components/header';
+import { PageHero } from '../components/ui/page-hero';
 import { articleCategories } from '../data/article-categories';
 import Layout from '../layouts/layout.astro';
 ---
@@ -7,18 +8,10 @@ import Layout from '../layouts/layout.astro';
 <Layout title="ナレッジベース | Beekle">
  <Header client:load />
  <main class="pt-20">
-   <!-- Hero Section -->
-   <section class="relative py-32 bg-primary-500">
-     <div class="absolute inset-0 bg-grid-pattern opacity-10"></div>
-     <div class="container mx-auto px-8">
-       <h1 class="text-4xl md:text-6xl font-bold text-white text-center mb-8">
-         技術ナレッジベース
-       </h1>
-       <p class="text-xl text-white/90 text-center max-w-3xl mx-auto">
-         システム開発に関する知見を体系的にまとめています
-       </p>
-     </div>
-   </section>
+   <PageHero
+     title="技術ナレッジベース"
+     subtitle="システム開発に関する知見を体系的にまとめています"
+   />
 
    <!-- Articles Section -->
    <section class="py-24">

--- a/src/pages/materials.astro
+++ b/src/pages/materials.astro
@@ -1,5 +1,6 @@
 ---
 import { Header } from '../components/header';
+import { PageHero } from '../components/ui/page-hero';
 import Layout from '../layouts/layout.astro';
 
 const materials = [
@@ -17,16 +18,10 @@ const materials = [
 <Layout title="関連資料 | Beekle">
   <Header client:load />
   <main class="pt-20">
-    <section class="bg-primary-500 py-20">
-      <div class="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl text-center">
-        <h1 class="text-4xl font-bold text-white sm:text-5xl mb-6">
-          関連資料
-        </h1>
-        <p class="text-xl text-white/90 max-w-3xl mx-auto">
-          各種資料をダウンロードいただけます
-        </p>
-      </div>
-    </section>
+    <PageHero
+      title="関連資料"
+      subtitle="各種資料をダウンロードいただけます"
+    />
 
     <section class="mx-auto px-4 sm:px-6 lg:px-8 max-w-7xl py-16">
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">

--- a/src/pages/members.astro
+++ b/src/pages/members.astro
@@ -2,6 +2,7 @@
 import Layout from '@/layouts/layout.astro';
 import { Header } from '../components/header';
 import MemberCard from '../components/member-card';
+import { PageHero } from '../components/ui/page-hero';
 
 interface Member {
   id: number;
@@ -59,18 +60,10 @@ const members: Member[] = [
 <Layout title="メンバー紹介 | Beekle">
   <Header client:load />
   <main class="pt-20">
-    <!-- ヒーローセクション -->
-    <section class="relative py-32 bg-primary-500">
-      <div class="absolute inset-0 bg-grid-pattern opacity-10"></div>
-      <div class="container mx-auto px-8">
-        <h1 class="text-4xl md:text-6xl font-bold text-white text-center mb-8">
-          MEMBERS
-        </h1>
-        <p class="text-xl text-white/90 text-center max-w-3xl mx-auto leading-relaxed">
-          Beekleの開発チームをご紹介します。多様な専門知識と経験を持つ私たちが、お客様のビジネス成長を全力でサポートします。
-        </p>
-      </div>
-    </section>
+    <PageHero
+      title="メンバー紹介"
+      subtitle="Beekleの開発チームをご紹介します。多様な専門知識と経験を持つ私たちが、お客様のビジネス成長を全力でサポートします。"
+    />
 
     <!-- メンバー紹介セクション -->
     <section class="py-32 bg-gray-50">

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -12,7 +12,6 @@ const lastUpdated = '2024年1月1日';
   <main class="pt-20">
     <!-- Hero Section -->
     <PageHero
-      englishTitle="PRIVACY"
       title="プライバシーポリシー"
       subtitle={`最終更新日: ${lastUpdated}`}
     />

--- a/src/pages/process.astro
+++ b/src/pages/process.astro
@@ -2,14 +2,19 @@
 import { CTASection } from '@/components/process-cta-section';
 import { ProcessFAQ } from '@/components/process-faq-section';
 // src/pages/process.astro
-import { ProcessHero } from '@/components/process-hero';
 import { ProcessSteps } from '@/components/process-steps';
+import { Header } from '../components/header';
+import { PageHero } from '../components/ui/page-hero';
 import Layout from '../layouts/layout.astro';
 ---
 
 <Layout title="導入の流れ | CDP構築サービス">
-  <main>
-    <ProcessHero client:load />
+  <Header client:load />
+  <main class="pt-20">
+    <PageHero
+      title="導入の流れ"
+      subtitle="お問い合わせから運用開始まで、段階的に進めていきます"
+    />
     <ProcessSteps client:load />
     <ProcessFAQ client:load />
     <CTASection client:load />

--- a/src/pages/strengths.astro
+++ b/src/pages/strengths.astro
@@ -12,23 +12,26 @@ import Layout from '../layouts/layout.astro';
   <main class="pt-20">
     <!-- Hero Section -->
     <PageHero
-      englishTitle="STRENGTHS"
       title="Beekleの強み"
-      subtitle="お客様のビジネス成功を実現する、私たちの3つの強み"
+      subtitle="お客様のビジネス成功を実現する、私たちの4つの強み"
     />
 
     <!-- 強み1: 要件定義力 -->
     <Section variant="white" padding="lg" decoration="blursPurple">
       <div class="grid lg:grid-cols-2 gap-16 items-center">
         <div class="relative">
-          <span class="font-Poppins text-[120px] lg:text-[180px] font-bold text-primary-500/10 absolute -top-16 -left-8 select-none">
+          <span
+            class="font-Poppins text-[120px] lg:text-[180px] font-bold text-primary-500/10 absolute -top-16 -left-8 select-none"
+          >
             01
           </span>
           <div class="relative z-10">
             <h2 class="text-3xl md:text-4xl font-bold text-accent-950 mb-4">
               卓越した<br /><span class="text-primary-500">要件定義力</span>
             </h2>
-            <span class="inline-block px-3 py-1 bg-primary-100 text-primary-600 rounded-full text-sm font-medium mb-8">
+            <span
+              class="inline-block px-3 py-1 bg-primary-100 text-primary-600 rounded-full text-sm font-medium mb-8"
+            >
               Strength
             </span>
             <p class="text-xl text-neutral-700 leading-relaxed">
@@ -39,7 +42,9 @@ import Layout from '../layouts/layout.astro';
 
         <div>
           <Card variant="outlinedPrimary" padding="lg" hover="none">
-            <h3 class="text-2xl font-bold text-accent-950 mb-6 flex items-center">
+            <h3
+              class="text-2xl font-bold text-accent-950 mb-6 flex items-center"
+            >
               <span class="w-2 h-8 bg-primary-500 rounded-full mr-4"></span>
               なぜ要件定義が重要なのか
             </h3>
@@ -70,7 +75,9 @@ import Layout from '../layouts/layout.astro';
       <div class="grid lg:grid-cols-2 gap-16 items-center">
         <div class="order-2 lg:order-1">
           <Card variant="outlinedPrimary" padding="lg" hover="none">
-            <h3 class="text-2xl font-bold text-accent-950 mb-6 flex items-center">
+            <h3
+              class="text-2xl font-bold text-accent-950 mb-6 flex items-center"
+            >
               <span class="w-2 h-8 bg-primary-500 rounded-full mr-4"></span>
               プロアクティブなアプローチ
             </h3>
@@ -80,42 +87,85 @@ import Layout from '../layouts/layout.astro';
 
             <div class="space-y-6">
               <div class="flex items-start gap-4 group">
-                <div class="w-12 h-12 bg-primary-500 rounded-xl flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
-                  <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                <div
+                  class="w-12 h-12 bg-primary-500 rounded-xl flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform"
+                >
+                  <svg
+                    class="w-6 h-6 text-white"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M5 13l4 4L19 7"></path>
                   </svg>
                 </div>
-                <p class="text-neutral-700">開発依頼の背景と事業詳細の徹底的なヒアリング</p>
+                <p class="text-neutral-700">
+                  開発依頼の背景と事業詳細の徹底的なヒアリング
+                </p>
               </div>
               <div class="flex items-start gap-4 group">
-                <div class="w-12 h-12 bg-primary-500 rounded-xl flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
-                  <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                <div
+                  class="w-12 h-12 bg-primary-500 rounded-xl flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform"
+                >
+                  <svg
+                    class="w-6 h-6 text-white"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M5 13l4 4L19 7"></path>
                   </svg>
                 </div>
-                <p class="text-neutral-700">顧客企業の強みを正確に把握した上での提案</p>
+                <p class="text-neutral-700">
+                  顧客企業の強みを正確に把握した上での提案
+                </p>
               </div>
               <div class="flex items-start gap-4 group">
-                <div class="w-12 h-12 bg-primary-500 rounded-xl flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
-                  <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                <div
+                  class="w-12 h-12 bg-primary-500 rounded-xl flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform"
+                >
+                  <svg
+                    class="w-6 h-6 text-white"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M5 13l4 4L19 7"></path>
                   </svg>
                 </div>
-                <p class="text-neutral-700">運用段階での価値最大化を見据えた機能設計</p>
+                <p class="text-neutral-700">
+                  運用段階での価値最大化を見据えた機能設計
+                </p>
               </div>
             </div>
           </Card>
         </div>
 
         <div class="order-1 lg:order-2 relative">
-          <span class="font-Poppins text-[120px] lg:text-[180px] font-bold text-primary-500/10 absolute -top-16 -right-8 select-none">
+          <span
+            class="font-Poppins text-[120px] lg:text-[180px] font-bold text-primary-500/10 absolute -top-16 -right-8 select-none"
+          >
             02
           </span>
           <div class="relative z-10">
             <h2 class="text-3xl md:text-4xl font-bold text-accent-950 mb-4">
               高度な<br /><span class="text-primary-500">問題解決能力</span>
             </h2>
-            <span class="inline-block px-3 py-1 bg-primary-100 text-primary-600 rounded-full text-sm font-medium mb-8">
+            <span
+              class="inline-block px-3 py-1 bg-primary-100 text-primary-600 rounded-full text-sm font-medium mb-8"
+            >
               Strength
             </span>
             <p class="text-xl text-neutral-700 leading-relaxed mb-8">
@@ -134,10 +184,14 @@ import Layout from '../layouts/layout.astro';
     <!-- 強み3: 学習意欲の高いチーム -->
     <Section variant="white" padding="lg" decoration="bars">
       <div class="text-center mb-16 relative">
-        <span class="font-Poppins text-[120px] lg:text-[180px] font-bold text-primary-500/10 absolute -top-16 right-1/4 select-none">
+        <span
+          class="font-Poppins text-[120px] lg:text-[180px] font-bold text-primary-500/10 absolute -top-16 right-1/4 select-none"
+        >
           03
         </span>
-        <span class="inline-block px-3 py-1 bg-primary-100 text-primary-600 rounded-full text-sm font-medium mb-4">
+        <span
+          class="inline-block px-3 py-1 bg-primary-100 text-primary-600 rounded-full text-sm font-medium mb-4"
+        >
           Strength
         </span>
         <h2 class="text-3xl md:text-4xl font-bold text-accent-950 mb-4">
@@ -159,8 +213,18 @@ import Layout from '../layouts/layout.astro';
       <div class="grid lg:grid-cols-3 gap-8">
         <Card variant="white" padding="lg" hover="lift" decoration="barPurple">
           <CardIcon variant="purple">
-            <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+            <svg
+              class="w-8 h-8"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+              ></path>
             </svg>
           </CardIcon>
           <CardTitle className="text-xl mb-3">週次勉強会</CardTitle>
@@ -171,8 +235,18 @@ import Layout from '../layouts/layout.astro';
 
         <Card variant="white" padding="lg" hover="lift" decoration="barPurple">
           <CardIcon variant="purple">
-            <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+            <svg
+              class="w-8 h-8"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+              ></path>
             </svg>
           </CardIcon>
           <CardTitle className="text-xl mb-3">知識共有文化</CardTitle>
@@ -183,14 +257,626 @@ import Layout from '../layouts/layout.astro';
 
         <Card variant="white" padding="lg" hover="lift" decoration="barPurple">
           <CardIcon variant="purple">
-            <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
+            <svg
+              class="w-8 h-8"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+              ></path>
             </svg>
           </CardIcon>
           <CardTitle className="text-xl mb-3">実践的な学習</CardTitle>
           <CardDescription>
             新しい技術を実際のプロジェクトに適用し、最適なソリューションを提供します。
           </CardDescription>
+        </Card>
+      </div>
+    </Section>
+
+    <!-- 強み4: シナリオ設計力 -->
+    <Section variant="lightPurple" padding="lg" decoration="blursMix">
+      <!-- タイトル部分：中央配置 -->
+      <div class="text-center mb-16 relative">
+        <span
+          class="font-Poppins text-[120px] lg:text-[180px] font-bold text-primary-500/10 absolute -top-16 left-1/4 select-none"
+        >
+          04
+        </span>
+        <span
+          class="inline-block px-3 py-1 bg-primary-100 text-primary-600 rounded-full text-sm font-medium mb-4"
+        >
+          Strength
+        </span>
+        <h2 class="text-3xl md:text-4xl font-bold text-accent-950 mb-4">
+          ビジネスから逆算する<br /><span class="text-primary-500"
+            >シナリオ設計力</span
+          >
+        </h2>
+        <p class="text-lg text-neutral-600 max-w-3xl mx-auto">
+          UXをしっかり設計し、ビジネス上の目的から逆算してシステムの振る舞いを定義。<br
+          />
+          無駄な開発をせず、<span class="font-bold text-accent-950"
+            >納得感を持ってプロジェクトを進められる</span
+          >から、最小コストで最大の費用対効果を実現します。
+        </p>
+      </div>
+
+      <!-- 具体的な手法：2カラム -->
+      <div class="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto mb-12">
+        <Card variant="white" padding="lg" hover="lift" decoration="barPurple">
+          <CardIcon variant="purple">
+            <svg
+              class="w-8 h-8"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
+              ></path>
+            </svg>
+          </CardIcon>
+          <CardTitle className="text-xl mb-3">Figmaプロトタイプ</CardTitle>
+          <CardDescription>
+            実際の画面イメージを見ながらヒアリング。認識のズレを早期に解消し、手戻りを防ぎます。
+          </CardDescription>
+        </Card>
+
+        <Card variant="white" padding="lg" hover="lift" decoration="barPurple">
+          <CardIcon variant="purple">
+            <svg
+              class="w-8 h-8"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              ></path>
+            </svg>
+          </CardIcon>
+          <CardTitle className="text-xl mb-3">BDD（振る舞い駆動開発）</CardTitle
+          >
+          <CardDescription>
+            システムの「振る舞い」をビジネス視点で定義。全員が読める「生きた仕様書」を作成します。
+          </CardDescription>
+        </Card>
+      </div>
+
+      <!-- BDD解説セクション -->
+      <div class="max-w-5xl mx-auto mb-12">
+        <Card variant="outlinedPrimary" padding="lg" hover="none">
+          <h3 class="text-xl font-bold text-accent-950 mb-6 flex items-center">
+            <svg
+              class="w-6 h-6 text-primary-500 mr-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              ></path>
+            </svg>
+            BDDで「生きた仕様書」を作成
+          </h3>
+
+          <div class="grid lg:grid-cols-3 gap-6 mb-6">
+            <div class="bg-primary-50 rounded-lg p-4">
+              <p class="text-xs text-primary-600 mb-2 font-bold">
+                1. ユースケース定義
+              </p>
+              <p class="text-sm text-neutral-700">
+                ビジネス価値の高い順に機能を整理し、優先度・工数・シナリオ数を明確化
+              </p>
+            </div>
+            <div class="bg-primary-50 rounded-lg p-4">
+              <p class="text-xs text-primary-600 mb-2 font-bold">
+                2. シナリオ詳細化
+              </p>
+              <p class="text-sm text-neutral-700">
+                Given-When-Then形式で全員が読める振る舞いを定義
+              </p>
+            </div>
+            <div class="bg-primary-50 rounded-lg p-4">
+              <p class="text-xs text-primary-600 mb-2 font-bold">
+                3. 受け入れ基準
+              </p>
+              <p class="text-sm text-neutral-700">
+                チェックリスト形式で「完了」の定義を明確化
+              </p>
+            </div>
+          </div>
+
+          <div class="grid lg:grid-cols-2 gap-6 items-start">
+            <!-- Gherkin記法の例 -->
+            <div>
+              <p class="text-xs text-neutral-500 mb-2 font-medium">
+                Gherkin記法でシナリオを記述
+              </p>
+              <div class="bg-accent-950 rounded-lg p-4 font-mono text-xs">
+                <p class="text-primary-400">
+                  Feature: <span class="text-white">ログイン機能</span>
+                </p>
+                <p class="text-primary-400 mt-2">
+                  Scenario: <span class="text-white"
+                    >正しい認証情報でログイン</span
+                  >
+                </p>
+                <p class="text-green-400 mt-2 ml-2">
+                  Given<span class="text-neutral-500 text-[10px]">（前提）</span
+                  >
+                  <span class="text-white">ログインページが表示されている</span>
+                </p>
+                <p class="text-yellow-400 ml-2">
+                  When<span class="text-neutral-500 text-[10px]">（操作）</span>
+                  <span class="text-white"
+                    >正しいID/PWでログインボタンを押す</span
+                  >
+                </p>
+                <p class="text-blue-400 ml-2">
+                  Then<span class="text-neutral-500 text-[10px]">（結果）</span>
+                  <span class="text-white"
+                    >ホームページにリダイレクトされる</span
+                  >
+                </p>
+              </div>
+              <p class="text-xs text-neutral-500 mt-2">
+                開発者・QA・ビジネス担当者など<span class="font-bold"
+                  >全員が読める</span
+                >ため、認識の齟齬を埋めます。
+              </p>
+            </div>
+
+            <!-- 実装設計書の構成 -->
+            <div>
+              <p class="text-xs text-neutral-500 mb-2 font-medium">
+                さらに実装設計書として詳細化
+              </p>
+              <div class="bg-neutral-50 rounded-lg p-4 text-sm space-y-2">
+                <div class="flex items-center gap-2">
+                  <span
+                    class="w-5 h-5 bg-primary-500 text-white rounded text-xs flex items-center justify-center"
+                    >1</span
+                  >
+                  <span class="text-neutral-700"
+                    >ユースケース一覧と優先度マップ</span
+                  >
+                </div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class="w-5 h-5 bg-primary-500 text-white rounded text-xs flex items-center justify-center"
+                    >2</span
+                  >
+                  <span class="text-neutral-700"
+                    >各ユースケースの詳細シナリオ</span
+                  >
+                </div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class="w-5 h-5 bg-primary-500 text-white rounded text-xs flex items-center justify-center"
+                    >3</span
+                  >
+                  <span class="text-neutral-700"
+                    >技術仕様（DB設計・API設計）</span
+                  >
+                </div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class="w-5 h-5 bg-primary-500 text-white rounded text-xs flex items-center justify-center"
+                    >4</span
+                  >
+                  <span class="text-neutral-700"
+                    >非機能要件（パフォーマンス・エラー処理）</span
+                  >
+                </div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class="w-5 h-5 bg-primary-500 text-white rounded text-xs flex items-center justify-center"
+                    >5</span
+                  >
+                  <span class="text-neutral-700"
+                    >テスト戦略とカバレッジ目標</span
+                  >
+                </div>
+                <div class="flex items-center gap-2">
+                  <span
+                    class="w-5 h-5 bg-primary-500 text-white rounded text-xs flex items-center justify-center"
+                    >6</span
+                  >
+                  <span class="text-neutral-700">実装計画とリスク管理</span>
+                </div>
+              </div>
+              <p class="text-xs text-neutral-500 mt-2">
+                ここまで設計すれば<span class="font-bold"
+                  >「何を作るか」が完全に明確</span
+                >になります。
+              </p>
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      <!-- 実装設計書の例 -->
+      <div class="max-w-4xl mx-auto">
+        <p class="text-center text-sm text-neutral-500 mb-4">
+          ▼ 実装設計書の例（イメージ）
+        </p>
+
+        <!-- ドキュメント風カード -->
+        <div
+          class="bg-white rounded-2xl shadow-medium overflow-hidden border border-neutral-200"
+        >
+          <!-- ドキュメントヘッダー -->
+          <div
+            class="bg-neutral-100 px-6 py-3 border-b border-neutral-200 flex items-center gap-3"
+          >
+            <div class="flex gap-1.5">
+              <div class="w-3 h-3 rounded-full bg-red-400"></div>
+              <div class="w-3 h-3 rounded-full bg-yellow-400"></div>
+              <div class="w-3 h-3 rounded-full bg-green-400"></div>
+            </div>
+            <span class="text-xs text-neutral-500 font-mono"
+              >実装設計書_ツイート投稿機能.md</span
+            >
+          </div>
+
+          <!-- ドキュメント本文 -->
+          <div
+            class="p-6 font-mono text-sm leading-relaxed space-y-4 max-h-[480px] overflow-y-auto"
+          >
+            <!-- タイトル -->
+            <div>
+              <p class="text-xl font-bold text-accent-950">
+                # ツイート投稿機能 実装設計書
+              </p>
+            </div>
+
+            <!-- 概要テーブル -->
+            <div class="bg-neutral-50 rounded-lg p-4 not-italic">
+              <p class="text-xs text-neutral-500 mb-2">## 概要</p>
+              <div class="grid grid-cols-4 gap-2 text-center text-xs">
+                <div class="bg-white rounded p-2">
+                  <p class="text-neutral-400">工数</p>
+                  <p class="font-bold text-accent-950">5営業日</p>
+                </div>
+                <div class="bg-white rounded p-2">
+                  <p class="text-neutral-400">UC数</p>
+                  <p class="font-bold text-accent-950">6件</p>
+                </div>
+                <div class="bg-white rounded p-2">
+                  <p class="text-neutral-400">シナリオ</p>
+                  <p class="font-bold text-accent-950">19件</p>
+                </div>
+                <div class="bg-white rounded p-2">
+                  <p class="text-neutral-400">カバレッジ</p>
+                  <p class="font-bold text-accent-950">100%</p>
+                </div>
+              </div>
+            </div>
+
+            <!-- 目次 -->
+            <div>
+              <p class="text-neutral-500 text-xs mb-2">## 目次</p>
+              <div class="text-xs text-primary-600 space-y-1 ml-2">
+                <p>1. ユースケース一覧</p>
+                <p>2. ユースケース詳細</p>
+                <p>3. 技術仕様（DB設計・API設計）</p>
+                <p>4. 非機能要件</p>
+                <p>5. テスト戦略</p>
+                <p>6. 実装計画とリスク管理</p>
+              </div>
+            </div>
+
+            <!-- ユースケース一覧 -->
+            <div>
+              <p class="text-neutral-500 text-xs mb-2">
+                ## 1. ユースケース一覧
+              </p>
+              <div class="text-xs space-y-1 ml-2">
+                <p class="text-neutral-700">
+                  | ID | ユースケース | 優先度 | 工数 |
+                </p>
+                <p class="text-neutral-400">
+                  |------|------------|------|-----|
+                </p>
+                <p class="text-neutral-700">
+                  | UC-01 | ツイートを投稿する | <span class="text-red-500"
+                    >最高</span
+                  > | 1日 |
+                </p>
+                <p class="text-neutral-700">
+                  | UC-02 | ツイートを削除する | <span class="text-red-500"
+                    >最高</span
+                  > | 0.5日 |
+                </p>
+                <p class="text-neutral-700">
+                  | UC-03 | ツイートにいいねする | <span class="text-orange-500"
+                    >高</span
+                  > | 0.5日 |
+                </p>
+                <p class="text-neutral-400">| ... | 他3件 | | |</p>
+              </div>
+            </div>
+
+            <!-- ユースケース詳細 -->
+            <div>
+              <p class="text-neutral-500 text-xs mb-2">
+                ## 2. ユースケース詳細
+              </p>
+              <p class="text-neutral-500 text-xs ml-2 mb-1">
+                ### UC-01: ツイートを投稿する
+              </p>
+              <!-- メタ情報 -->
+              <div class="ml-2 mb-2 text-[9px] space-y-0.5">
+                <p class="text-neutral-600">
+                  <span class="text-neutral-400">アクター:</span> ログイン済みユーザー
+                </p>
+                <p class="text-neutral-600">
+                  <span class="text-neutral-400">ビジネス価値:</span> UGC増加 → エンゲージメント向上
+                </p>
+                <p class="text-neutral-600">
+                  <span class="text-neutral-400">前提条件:</span> ユーザーがログイン済み
+                </p>
+              </div>
+              <!-- 正常系 -->
+              <p class="text-[10px] ml-2 mb-1 text-green-600 font-bold">
+                ✓ 正常系
+              </p>
+              <div class="bg-accent-950 rounded-lg p-2 ml-2 text-[10px] mb-2">
+                <p class="text-primary-400">
+                  Scenario: <span class="text-white">ツイートを投稿する</span>
+                </p>
+                <p class="text-green-400 mt-1 ml-2">
+                  Given<span class="text-neutral-500">（前提）</span>
+                  <span class="text-white">投稿画面を表示している</span>
+                </p>
+                <p class="text-yellow-400 ml-2">
+                  When<span class="text-neutral-500">（操作）</span>
+                  <span class="text-white">「こんにちは」と入力して投稿</span>
+                </p>
+                <p class="text-blue-400 ml-2">
+                  Then<span class="text-neutral-500">（結果）</span>
+                  <span class="text-white">タイムラインに表示される</span>
+                </p>
+              </div>
+              <!-- 異常系（複数シナリオ） -->
+              <p class="text-[10px] ml-2 mb-1 text-red-500 font-bold">
+                ✗ 異常系（想定されるエラーを網羅）
+              </p>
+              <div class="bg-accent-950 rounded-lg p-2 ml-2 text-[10px] mb-1">
+                <p class="text-primary-400">
+                  Scenario 1: <span class="text-white"
+                    >文字数オーバーの場合</span
+                  >
+                </p>
+                <p class="text-yellow-400 ml-2">
+                  When<span class="text-neutral-500">（操作）</span>
+                  <span class="text-white">141文字以上を入力</span>
+                </p>
+                <p class="text-blue-400 ml-2">
+                  Then<span class="text-neutral-500">（結果）</span>
+                  <span class="text-white">投稿ボタンが無効化される</span>
+                </p>
+              </div>
+              <div class="bg-accent-950 rounded-lg p-2 ml-2 text-[10px] mb-1">
+                <p class="text-primary-400">
+                  Scenario 2: <span class="text-white">API接続エラー時</span>
+                </p>
+                <p class="text-yellow-400 ml-2">
+                  When<span class="text-neutral-500">（操作）</span>
+                  <span class="text-white">サーバーがタイムアウト</span>
+                </p>
+                <p class="text-blue-400 ml-2">
+                  Then<span class="text-neutral-500">（結果）</span>
+                  <span class="text-white">下書き保存し、リトライを促す</span>
+                </p>
+              </div>
+              <div class="bg-accent-950 rounded-lg p-2 ml-2 text-[10px] mb-1">
+                <p class="text-primary-400">
+                  Scenario 3: <span class="text-white"
+                    >冪等性（何度実行しても同じ結果）</span
+                  >
+                </p>
+                <p class="text-yellow-400 ml-2">
+                  When<span class="text-neutral-500">（操作）</span>
+                  <span class="text-white"
+                    >通信不安定で同一リクエストが3回届く</span
+                  >
+                </p>
+                <p class="text-blue-400 ml-2">
+                  Then<span class="text-neutral-500">（結果）</span>
+                  <span class="text-white">冪等キーで識別し、1件のみ登録</span>
+                </p>
+              </div>
+              <div class="bg-accent-950 rounded-lg p-2 ml-2 text-[10px] mb-1">
+                <p class="text-primary-400">
+                  Scenario 4: <span class="text-white"
+                    >重複コンテンツ（スパム防止）</span
+                  >
+                </p>
+                <p class="text-yellow-400 ml-2">
+                  When<span class="text-neutral-500">（操作）</span>
+                  <span class="text-white">同じ文面を意図的に連続投稿</span>
+                </p>
+                <p class="text-blue-400 ml-2">
+                  Then<span class="text-neutral-500">（結果）</span>
+                  <span class="text-white"
+                    >「先ほど同じ内容を投稿しました」エラー</span
+                  >
+                </p>
+              </div>
+              <div class="bg-accent-950 rounded-lg p-2 ml-2 text-[10px] mb-1">
+                <p class="text-primary-400">
+                  Scenario 5: <span class="text-white">不正な文字列（XSS）</span
+                  >
+                </p>
+                <p class="text-yellow-400 ml-2">
+                  When<span class="text-neutral-500">（操作）</span>
+                  <span class="text-white">scriptタグを含む投稿</span>
+                </p>
+                <p class="text-blue-400 ml-2">
+                  Then<span class="text-neutral-500">（結果）</span>
+                  <span class="text-white">サニタイズして安全に保存</span>
+                </p>
+              </div>
+              <div class="bg-accent-950 rounded-lg p-2 ml-2 text-[10px] mb-1">
+                <p class="text-primary-400">
+                  Scenario 6: <span class="text-white">セッション切れ</span>
+                </p>
+                <p class="text-yellow-400 ml-2">
+                  When<span class="text-neutral-500">（操作）</span>
+                  <span class="text-white">ログアウト状態で投稿試行</span>
+                </p>
+                <p class="text-blue-400 ml-2">
+                  Then<span class="text-neutral-500">（結果）</span>
+                  <span class="text-white">下書き保存後、ログイン画面へ</span>
+                </p>
+              </div>
+              <div class="bg-accent-950 rounded-lg p-2 ml-2 text-[10px]">
+                <p class="text-primary-400">
+                  Scenario 7: <span class="text-white"
+                    >トラフィックスパイク</span
+                  >
+                </p>
+                <p class="text-yellow-400 ml-2">
+                  When<span class="text-neutral-500">（操作）</span>
+                  <span class="text-white">バズ発生で100倍のアクセス</span>
+                </p>
+                <p class="text-blue-400 ml-2">
+                  Then<span class="text-neutral-500">（結果）</span>
+                  <span class="text-white">Rate Limit適用、キュー処理</span>
+                </p>
+              </div>
+              <p class="text-[8px] ml-2 mt-1 text-neutral-400 italic">
+                ※ 想定エラーを事前にシナリオ化 → トラブル防止 & 品質担保
+              </p>
+            </div>
+
+            <!-- 技術仕様 -->
+            <div>
+              <p class="text-neutral-500 text-xs mb-2">## 3. 技術仕様</p>
+              <p class="text-neutral-500 text-xs ml-2 mb-1">### ER図</p>
+              <!-- ER図風 -->
+              <div class="ml-2 mb-3 flex gap-2 items-center text-[10px]">
+                <div
+                  class="border border-neutral-300 rounded bg-white p-2 text-center"
+                >
+                  <p class="font-bold border-b border-neutral-200 pb-1 mb-1">
+                    users
+                  </p>
+                  <p class="text-neutral-600">id, name, email</p>
+                </div>
+                <span class="text-neutral-400">1 ─── *</span>
+                <div
+                  class="border border-neutral-300 rounded bg-white p-2 text-center"
+                >
+                  <p class="font-bold border-b border-neutral-200 pb-1 mb-1">
+                    tweets
+                  </p>
+                  <p class="text-neutral-600">id, content, user_id</p>
+                </div>
+              </div>
+              <p class="text-neutral-500 text-xs ml-2 mb-1">
+                ### API設計（OpenAPI）
+              </p>
+              <div class="bg-accent-950 rounded-lg p-3 ml-2 text-[10px]">
+                <p class="text-yellow-400">
+                  openapi: <span class="text-white">3.0.0</span>
+                </p>
+                <p class="text-yellow-400">paths:</p>
+                <p class="text-white ml-2">/tweets:</p>
+                <p class="text-green-400 ml-4">post:</p>
+                <p class="text-white ml-6">
+                  summary: <span class="text-cyan-300">ツイートを投稿</span>
+                </p>
+                <p class="text-white ml-6">requestBody:</p>
+                <p class="text-white ml-8">
+                  content: <span class="text-cyan-300">string</span>
+                </p>
+              </div>
+            </div>
+
+            <!-- 非機能要件 -->
+            <div>
+              <p class="text-neutral-500 text-xs mb-2">## 4. 非機能要件</p>
+              <div class="text-xs ml-2 space-y-1">
+                <p class="text-neutral-700">- スループット: 50万件/秒</p>
+                <p class="text-neutral-700">- データ量: 1日5億件想定</p>
+                <p class="text-neutral-700">
+                  - 整合性: 結果整合性（シャーディング）
+                </p>
+              </div>
+            </div>
+
+            <!-- テスト戦略 -->
+            <div>
+              <p class="text-neutral-500 text-xs mb-2">## 5. テスト戦略</p>
+              <div class="text-xs ml-2">
+                <p class="text-neutral-700">| レベル | カバレッジ目標 |</p>
+                <p class="text-neutral-400">|------|------------|</p>
+                <p class="text-neutral-700">| 単体テスト | 80%以上 |</p>
+                <p class="text-neutral-700">| 統合テスト | 全UC |</p>
+                <p class="text-neutral-700">| E2Eテスト | 全19シナリオ |</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <p class="text-xs text-neutral-500 mt-4 text-center">
+          ※ 実際のプロジェクトでは、このような設計書を作成してから実装に入ります
+        </p>
+      </div>
+
+      <!-- ドキュメント管理の考え方 -->
+      <div class="max-w-2xl mx-auto mt-12 mb-8 text-center">
+        <p class="text-neutral-600 leading-relaxed">
+          エクセルでドキュメントを大量に作る会社が結構ありますが、ドキュメントは<span
+            class="text-red-500 font-medium">作りすぎても形骸化</span
+          >、<span class="text-red-500 font-medium">作らなさすぎても曖昧</span
+          >になります。<br />
+          大切なのは<span class="font-bold text-accent-950"
+            >「残すもの」と「捨てるもの」を分ける</span
+          >こと。<br />
+          <span class="text-sm text-neutral-500"
+            >ユースケース・ユーザーシナリオ実装設計書やAPI仕様は常に最新化。議事録や検討メモは役目を終えたら途中までの情報として履歴としての参照だけにする。
+          </span>
+        </p>
+      </div>
+
+      <!-- 結論 -->
+      <div class="max-w-3xl mx-auto">
+        <Card variant="lightPurple" padding="lg" hover="none">
+          <div class="text-center">
+            <p class="text-neutral-700 mb-4">
+              ここまで設計が固まっていれば、<span class="font-bold"
+                >生成AIを使ってコードを素早く書くことも可能</span
+              >です。<br />
+              コードを書くだけなら多くの開発会社ができます。
+            </p>
+            <p class="text-lg font-bold text-accent-950 mb-4">
+              しかし、ここまでプロセス化してチームで実践できる会社は多くありません。
+            </p>
+            <div class="inline-block bg-white rounded-xl px-6 py-4 shadow-soft">
+              <p class="text-lg font-bold text-primary-500">
+                🎯 だから他社が頓挫した案件も立て直せるのです。
+              </p>
+            </div>
+          </div>
         </Card>
       </div>
     </Section>
@@ -209,7 +895,9 @@ import Layout from '../layouts/layout.astro';
         <Card variant="outlinedPrimary" padding="lg" hover="none">
           <div class="flex items-start gap-6">
             <div class="flex-shrink-0">
-              <div class="w-16 h-16 bg-primary-500 rounded-2xl flex items-center justify-center">
+              <div
+                class="w-16 h-16 bg-primary-500 rounded-2xl flex items-center justify-center"
+              >
                 <span class="text-2xl font-bold text-white">Q</span>
               </div>
             </div>
@@ -220,12 +908,17 @@ import Layout from '../layouts/layout.astro';
 
               <div class="space-y-6">
                 <p class="text-lg text-neutral-700 leading-relaxed">
-                  <span class="font-bold text-primary-500">結論：むしろ小規模だからこその強みがあります。</span>
+                  <span class="font-bold text-primary-500"
+                    >結論：むしろ小規模だからこその強みがあります。</span
+                  >
                 </p>
 
                 <Card variant="lightPurple" padding="md" hover="none">
-                  <h4 class="text-xl font-bold text-accent-950 mb-3 flex items-center">
-                    <span class="w-2 h-6 bg-primary-500 rounded-full mr-3"></span>
+                  <h4
+                    class="text-xl font-bold text-accent-950 mb-3 flex items-center"
+                  >
+                    <span class="w-2 h-6 bg-primary-500 rounded-full mr-3"
+                    ></span>
                     大手案件の実態
                   </h4>
                   <p class="text-neutral-700 leading-relaxed">
@@ -235,9 +928,21 @@ import Layout from '../layouts/layout.astro';
 
                 <div class="grid md:grid-cols-2 gap-6">
                   <Card variant="white" padding="md" hover="lift">
-                    <h5 class="font-bold text-accent-950 mb-3 flex items-center">
-                      <svg class="w-6 h-6 text-primary-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                    <h5
+                      class="font-bold text-accent-950 mb-3 flex items-center"
+                    >
+                      <svg
+                        class="w-6 h-6 text-primary-500 mr-2"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                        ></path>
                       </svg>
                       コスト面のメリット
                     </h5>
@@ -247,9 +952,21 @@ import Layout from '../layouts/layout.astro';
                   </Card>
 
                   <Card variant="white" padding="md" hover="lift">
-                    <h5 class="font-bold text-accent-950 mb-3 flex items-center">
-                      <svg class="w-6 h-6 text-primary-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>
+                    <h5
+                      class="font-bold text-accent-950 mb-3 flex items-center"
+                    >
+                      <svg
+                        class="w-6 h-6 text-primary-500 mr-2"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+                        ></path>
                       </svg>
                       コミュニケーション
                     </h5>
@@ -274,7 +991,9 @@ import Layout from '../layouts/layout.astro';
         <Card variant="outlinedPrimary" padding="lg" hover="none">
           <div class="flex items-start gap-6">
             <div class="flex-shrink-0">
-              <div class="w-16 h-16 bg-primary-500 rounded-2xl flex items-center justify-center">
+              <div
+                class="w-16 h-16 bg-primary-500 rounded-2xl flex items-center justify-center"
+              >
                 <span class="text-2xl font-bold text-white">Q</span>
               </div>
             </div>
@@ -285,12 +1004,17 @@ import Layout from '../layouts/layout.astro';
 
               <div class="space-y-6">
                 <p class="text-lg text-neutral-700 leading-relaxed">
-                  <span class="font-bold text-primary-500">もちろんです。むしろ「わからない」と言っていただける方が助かります。</span>
+                  <span class="font-bold text-primary-500"
+                    >もちろんです。むしろ「わからない」と言っていただける方が助かります。</span
+                  >
                 </p>
 
                 <Card variant="lightPurple" padding="md" hover="none">
-                  <h4 class="text-xl font-bold text-accent-950 mb-3 flex items-center">
-                    <span class="w-2 h-6 bg-primary-500 rounded-full mr-3"></span>
+                  <h4
+                    class="text-xl font-bold text-accent-950 mb-3 flex items-center"
+                  >
+                    <span class="w-2 h-6 bg-primary-500 rounded-full mr-3"
+                    ></span>
                     専門用語を使わない説明
                   </h4>
                   <p class="text-neutral-700 leading-relaxed">
@@ -300,32 +1024,50 @@ import Layout from '../layouts/layout.astro';
 
                 <div class="space-y-4">
                   <div class="flex items-start gap-4">
-                    <div class="w-10 h-10 bg-primary-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                    <div
+                      class="w-10 h-10 bg-primary-100 rounded-lg flex items-center justify-center flex-shrink-0"
+                    >
                       <span class="text-primary-600 font-bold">1</span>
                     </div>
                     <div>
-                      <h5 class="font-bold text-accent-950 mb-1">まずは業務の課題をお聞きします</h5>
-                      <p class="text-neutral-700 text-sm">「在庫管理が大変」「顧客情報がバラバラ」など、日常の困りごとをそのままお話しください。</p>
+                      <h5 class="font-bold text-accent-950 mb-1">
+                        まずは業務の課題をお聞きします
+                      </h5>
+                      <p class="text-neutral-700 text-sm">
+                        「在庫管理が大変」「顧客情報がバラバラ」など、日常の困りごとをそのままお話しください。
+                      </p>
                     </div>
                   </div>
 
                   <div class="flex items-start gap-4">
-                    <div class="w-10 h-10 bg-primary-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                    <div
+                      class="w-10 h-10 bg-primary-100 rounded-lg flex items-center justify-center flex-shrink-0"
+                    >
                       <span class="text-primary-600 font-bold">2</span>
                     </div>
                     <div>
-                      <h5 class="font-bold text-accent-950 mb-1">解決策を一緒に考えます</h5>
-                      <p class="text-neutral-700 text-sm">システムありきではなく、エクセルで十分な部分、システム化すべき部分を整理してご提案します。</p>
+                      <h5 class="font-bold text-accent-950 mb-1">
+                        解決策を一緒に考えます
+                      </h5>
+                      <p class="text-neutral-700 text-sm">
+                        システムありきではなく、エクセルで十分な部分、システム化すべき部分を整理してご提案します。
+                      </p>
                     </div>
                   </div>
 
                   <div class="flex items-start gap-4">
-                    <div class="w-10 h-10 bg-primary-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                    <div
+                      class="w-10 h-10 bg-primary-100 rounded-lg flex items-center justify-center flex-shrink-0"
+                    >
                       <span class="text-primary-600 font-bold">3</span>
                     </div>
                     <div>
-                      <h5 class="font-bold text-accent-950 mb-1">段階的な導入をサポート</h5>
-                      <p class="text-neutral-700 text-sm">いきなり大きなシステムではなく、小さく始めて効果を確認しながら拡張していくことも可能です。</p>
+                      <h5 class="font-bold text-accent-950 mb-1">
+                        段階的な導入をサポート
+                      </h5>
+                      <p class="text-neutral-700 text-sm">
+                        いきなり大きなシステムではなく、小さく始めて効果を確認しながら拡張していくことも可能です。
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -338,7 +1080,9 @@ import Layout from '../layouts/layout.astro';
         <Card variant="outlinedPrimary" padding="lg" hover="none">
           <div class="flex items-start gap-6">
             <div class="flex-shrink-0">
-              <div class="w-16 h-16 bg-primary-500 rounded-2xl flex items-center justify-center">
+              <div
+                class="w-16 h-16 bg-primary-500 rounded-2xl flex items-center justify-center"
+              >
                 <span class="text-2xl font-bold text-white">Q</span>
               </div>
             </div>
@@ -349,14 +1093,28 @@ import Layout from '../layouts/layout.astro';
 
               <div class="space-y-6">
                 <p class="text-lg text-neutral-700 leading-relaxed">
-                  <span class="font-bold text-primary-500">選ぶ基準は「話を聞いてくれるか」と「実績があるか」です。</span>
+                  <span class="font-bold text-primary-500"
+                    >選ぶ基準は「話を聞いてくれるか」と「実績があるか」です。</span
+                  >
                 </p>
 
                 <div class="grid md:grid-cols-2 gap-6">
                   <Card variant="light" padding="md" hover="none">
-                    <h4 class="font-bold text-accent-950 mb-3 flex items-center">
-                      <svg class="w-6 h-6 text-green-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                    <h4
+                      class="font-bold text-accent-950 mb-3 flex items-center"
+                    >
+                      <svg
+                        class="w-6 h-6 text-green-600 mr-2"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                        ></path>
                       </svg>
                       良い開発会社の特徴
                     </h4>
@@ -369,9 +1127,21 @@ import Layout from '../layouts/layout.astro';
                   </Card>
 
                   <Card variant="light" padding="md" hover="none">
-                    <h4 class="font-bold text-accent-950 mb-3 flex items-center">
-                      <svg class="w-6 h-6 text-red-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                    <h4
+                      class="font-bold text-accent-950 mb-3 flex items-center"
+                    >
+                      <svg
+                        class="w-6 h-6 text-red-500 mr-2"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                        ></path>
                       </svg>
                       避けるべき会社の特徴
                     </h4>
@@ -398,14 +1168,23 @@ import Layout from '../layouts/layout.astro';
           ビジネスを成功へ
         </h2>
         <p class="text-xl text-white/90 mb-12 max-w-3xl mx-auto">
-          要件定義力、問題解決能力、そして学習意欲の高いチームが、<br />
-          お客様のプロジェクトを成功に導きます。
+          要件定義力、問題解決能力、学習意欲の高いチーム、<br />
+          そしてシナリオ設計力が、お客様のプロジェクトを成功に導きます。
         </p>
         <div class="flex flex-col sm:flex-row gap-6 justify-center">
           <ButtonLink href="/contact" variant="white" size="lg">
             無料相談を予約する
-            <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
+            <svg
+              class="w-5 h-5 ml-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
             </svg>
           </ButtonLink>
           <ButtonLink href="/prooffirst" variant="outline" size="lg">

--- a/src/pages/testimonial.astro
+++ b/src/pages/testimonial.astro
@@ -12,7 +12,6 @@ import Layout from '../layouts/layout.astro';
   <main class="pt-20">
     <!-- Hero Section -->
     <PageHero
-      englishTitle="TESTIMONIAL"
       title="お客様の声"
       subtitle="Beekleをご利用いただいているお客様からの貴重なフィードバックをご紹介します"
     />

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -33,7 +33,6 @@ const works = [
   <main class="pt-20">
     <!-- Hero Section -->
     <PageHero
-      englishTitle="WORKS"
       title="実績紹介"
       subtitle="Beekleがこれまでに手掛けた実績の一部をご紹介します。様々な分野で成果を上げてきたプロジェクトの詳細をご覧ください。"
     />


### PR DESCRIPTION
## Summary
- Strength 04「シナリオ設計力」セクションにTwitter投稿を題材にした具体例を実装
- 冪等性（リクエストID）と重複コンテンツ検知（コンテンツHash）を別シナリオとして分離
- ドキュメント管理の考え方（ストック情報 vs フロー情報）セクション追加

## Changes
- 19シナリオの網羅的なユースケース設計例（正常系・異常系・境界値・非機能要件）
- BDD (Gherkin記法) によるシナリオ表現
- PageHeroコンポーネントのmargin-bottom制御改善
- 各ページの不要なimport整理

## Test plan
- [ ] `bun dev` でローカル確認
- [ ] `/strengths` ページでStrength 04セクションの表示確認
- [ ] シナリオ一覧、E2Eテスト表、ドキュメント管理セクションの表示確認
- [ ] レスポンシブデザイン確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)