### PR TITLE
fix(seo): GSC 404 ドリルダウンの旧URLを 301 で吸収

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -2,8 +2,48 @@
 /column/7hhc1tib7dft  /column/ai-development-speed  301
 /column/nqu29zwuq6  /column/ai-era-development-flow  301
 
-# 旧 /service/* → 現 /services/*（SC 404 ドリルダウン由来、明確な対応のみ）
-/service/cdp                      /services/cdp-development         301
-/cdp                              /services/cdp-development         301
-/service/overseas-website         /services/global-service          301
-/service/application-development  /services/web-mobile-development  301
+# 旧 column 階層（/column/<category>/<slug>/）→ /column トップ
+/column/fast-development/*  /column  301
+/column/avoid-failure/*     /column  301
+
+# 旧 /service/* → 現 /services/*（SC 404 ドリルダウン由来）
+/service/cdp                       /services/cdp-development         301
+/service/cdp/                      /services/cdp-development         301
+/cdp                               /services/cdp-development         301
+/service/overseas-website          /services/global-service          301
+/service/overseas-website/         /services/global-service          301
+/service/application-development   /services/web-mobile-development  301
+/service/application-development/  /services/web-mobile-development  301
+/service/in-house-support          /services/web-mobile-development  301
+/service/in-house-support/         /services/web-mobile-development  301
+/service/insourcing                /services/web-mobile-development  301
+/service/insourcing/               /services/web-mobile-development  301
+/service/prototype                 /services/web-mobile-development  301
+/service/prototype/                /services/web-mobile-development  301
+
+# 削除された新形式 services パス
+/services/prototype-poc   /services  301
+/services/prototype-poc/  /services  301
+
+# 旧 knowledge ページ（column へ統合済み: コミット f76e661）
+/knowledge/*  /column  301
+/knowledge    /column  301
+/knowledge/   /column  301
+
+# 旧 development-issues ページ（削除済み）
+/development-issues/*  /case-studies  301
+/development-issues    /case-studies  301
+/development-issues/   /case-studies  301
+
+# 旧 works → case-studies（コミット fff3f29 で統合）
+/works   /case-studies  301
+/works/  /case-studies  301
+
+# WordPress 残骸（旧 CMS 由来）
+/feed/           /  301
+/feed            /  301
+/comments/feed/  /  301
+/comments/feed   /  301
+/category/*      /  301
+/2023/           /  301
+/2023            /  301


### PR DESCRIPTION
## Summary

GSC Coverage Drilldown 2026-04-30 で報告された **Not found (404) 30件** を分類して \`public/_redirects\` に 301 リダイレクトを追加。同時に Critical issues の **Server error (5xx) 22件**（すべて \`/knowledge/*\`）も吸収される見込み。

## 追加したリダイレクト

| 旧パス | 新パス | 件数 |
|---|---|---:|
| \`/knowledge/*\` | \`/column\` | 22 (5xx) + 1 (404) |
| \`/development-issues/*\` | \`/case-studies\` | 6 |
| \`/works\` | \`/case-studies\` | 1 |
| \`/service/*\` 末尾スラッシュ版・追加パターン | 適切な \`/services/*\` | 8 |
| \`/services/prototype-poc\` | \`/services\` | 1 |
| \`/column/fast-development/*\`, \`/column/avoid-failure/*\` | \`/column\` | 2 |
| WordPress 残骸（\`/feed\`, \`/category/*\`, \`/2023\` 等） | \`/\` | 5 |

## 対応外（要 GSC 手動対応）

- 日本語URL（\`/ホームページ開設...\` 等3件）→ wildcard 不可、GSC で「インデックスから削除」推奨
- \`/api/contact\`, \`/cdn-cgi/l/email-protection\` → 仕様上 404 で問題なし

## Safety

\`.claude/rules/cloudflare.md\` の警告（\`_redirects\` の末尾スラッシュ自己ループで本番破綻 2026-04-28）に該当しないことを確認：すべて「旧パス → **別の**新パス」の 301 で自己ループ無し。

## Test plan
- [x] \`bun run build\` 成功
- [x] \`dist/_redirects\` 生成確認
- [ ] デプロイ後 \`curl -sI https://beekle.jp/knowledge/agile-vs-waterfall\` → 301 → /column → 200
- [ ] デプロイ後 \`curl -sI https://beekle.jp/development-issues/project-delay\` → 301 → /case-studies → 200
- [ ] デプロイ後 \`curl -sI https://beekle.jp/service/insourcing/\` → 301 → /services/web-mobile-development → 200
- [ ] 既存正常パス（/, /column, /services/cdp-development）が依然 200 を返すことを確認
- [ ] GSC で「修正を検証」ボタン押下（5xx 22件 / 404 30件 の各 issue）

🤖 Generated with [Claude Code](https://claude.com/claude-code)