### PR TITLE
fix(seo): /services/ai-development の meta・Service JSON-LD を強化

### DIFF
--- a/src/components/seo/json-ld.astro
+++ b/src/components/seo/json-ld.astro
@@ -89,13 +89,25 @@ const serviceSchema = data.serviceName
       '@type': 'Service',
       name: data.serviceName,
       description: data.serviceDescription || '',
+      url: data.url || siteUrl,
+      ...(data.serviceType ? { serviceType: data.serviceType } : {}),
+      ...(data.image ? { image: data.image } : {}),
       provider: {
         '@type': 'Organization',
         name: 'Beekle株式会社',
+        url: siteUrl,
+        logo: `${siteUrl}/logo.png`,
       },
       areaServed: {
         '@type': 'Country',
         name: 'Japan',
+      },
+      offers: {
+        '@type': 'Offer',
+        name: '無料相談',
+        description: '初期費用0円のゼロスタートで、動くプロトタイプを体験してから判断できます。',
+        url: `${siteUrl}/contact`,
+        availability: 'https://schema.org/InStock',
       },
     }
   : null;

--- a/src/data/service.ts
+++ b/src/data/service.ts
@@ -496,9 +496,9 @@ export const services: ServiceDetail[] = [
       'ChatGPT・Claude・Gemini等のLLM、AIエージェント、RAG構築まで。生成AIを業務に組み込む受託開発サービス。',
     longDescription:
       'OpenAI（ChatGPT/GPT-4o）、Anthropic Claude、Google Gemini等のLLM API活用から、社内文書を活用するRAG（検索拡張生成）、業務を自律実行するAIエージェント、Stable Diffusionによる画像生成まで、生成AIを業務システムに組み込む受託開発を提供します。技術選定・PoC・本番化・運用まで一気通貫でサポート。Claude Code等のAI開発環境を活用し、要件定義から最短2週間でプロトタイプを提供できます。',
-    seoTitle: '生成AI受託開発｜ChatGPT・Claude API活用、AIエージェント・RAG構築',
+    seoTitle: '生成AI受託開発｜最短2週間でPoC｜ChatGPT・Claude・RAG・AIエージェント構築',
     seoDescription:
-      'ChatGPT・Claude・Gemini等LLM活用、RAG構築、AIエージェント開発の受託サービス。技術選定からPoC・本番化・運用まで一気通貫対応。生成AIで業務を自動化したい企業様向け。',
+      '生成AI受託開発の専門チームが、ChatGPT・Claude・Gemini活用、RAG・AIエージェント構築まで対応。最短2週間でPoCを提供し、業務に組み込めるか早期判断。初期費用0円のゼロスタートで無料相談から開始可能です。',
     painPoints: [
       {
         title: '技術選定の難しさ',

--- a/src/pages/services/[id].astro
+++ b/src/pages/services/[id].astro
@@ -29,6 +29,9 @@ const seoDescription = service.seoDescription ?? service.description;
     data={{
       serviceName: service.title,
       serviceDescription: service.description,
+      url: serviceUrl,
+      serviceType: service.title,
+      image: `${siteUrl}/og-image.png`,
     }}
   />
   <JsonLd
@@ -37,7 +40,6 @@ const seoDescription = service.seoDescription ?? service.description;
     data={{
       items: [
         { name: 'ホーム', url: '/' },
-        { name: 'サービス', url: '/' },
         { name: service.title, url: `/services/${service.id}` },
       ],
     }}


### PR DESCRIPTION
## Summary

GA4 で **imp 194 / clicks 1 / pos 39.3（CTR 0.5%）** と低調な \`/services/ai-development\` の SEO を強化。

### 変更点

- **seoTitle**: 「最短2週間でPoC」追加で差別化要素を明示
  - before: \`生成AI受託開発｜ChatGPT・Claude API活用、AIエージェント・RAG構築\`
  - after: \`生成AI受託開発｜最短2週間でPoC｜ChatGPT・Claude・RAG・AIエージェント構築\`
- **seoDescription**: 「初期費用0円のゼロスタート」「無料相談」を組み込み CTR 訴求強化
- **JSON-LD Service** スキーマに以下を追加:
  - \`url\`, \`serviceType\`, \`image\`
  - \`offers\` (無料相談, InStock, /contact)
  - \`provider.url\`, \`provider.logo\`
- **breadcrumb 誤誘導修正**: 「サービス → /」の2階層目を削除し、\`/services\` 一覧ページ不在に整合させた2階層構造に変更

## 副次効果（他 services にも反映）

JSON-LD コンポーネントの拡張は全 \`/services/*\` ページで有効。url/serviceType/image を任意 prop にしているため既存挙動は壊れない。

## Test plan
- [x] \`bun run build\` 成功
- [x] Biome lint pass（編集3ファイル）
- [x] \`/services/ai-development\` 200, meta tags / JSON-LD / breadcrumb 出力を curl で検証
- [x] H1 が「生成AI受託開発」で出力されることを確認
- [ ] デプロイ後 SERP の表示確認
- [ ] 1〜2週間後 GSC で imp / CTR / pos 改善の有無確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)