### PR TITLE
feat(cv): ツール3種にフローティングCTAを追加 (ツール離脱救済)

### DIFF
--- a/src/components/ui/floating-cta.astro
+++ b/src/components/ui/floating-cta.astro
@@ -1,0 +1,61 @@
+---
+export interface Props {
+  href: string;
+  label: string;
+  source: string;
+  ctaId: string;
+}
+
+const { href, label, source, ctaId } = Astro.props as Props;
+---
+
+<div
+  data-floating-cta
+  class="fixed bottom-4 right-4 sm:bottom-6 sm:right-6 z-40 max-w-[calc(100vw-2rem)] sm:max-w-sm hidden"
+>
+  <div
+    class="flex items-stretch gap-2 bg-primary-500 text-white rounded-full shadow-2xl pl-5 pr-2 py-2 ring-1 ring-primary-600/30 hover:bg-primary-600 transition-colors"
+  >
+    <a
+      href={href}
+      data-cta-source={source}
+      data-cta-id={ctaId}
+      class="tool-escape-cta flex items-center gap-2 text-sm font-semibold whitespace-nowrap"
+    >
+      <span>{label}</span>
+      <svg
+        class="w-4 h-4 flex-shrink-0"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+      </svg>
+    </a>
+    <button
+      type="button"
+      data-floating-cta-close
+      aria-label="閉じる"
+      class="flex items-center justify-center w-8 h-8 rounded-full hover:bg-primary-700 transition-colors flex-shrink-0"
+    >
+      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    </button>
+  </div>
+</div>
+
+<script>
+  const STORAGE_KEY = 'beekle-floating-cta-dismissed';
+  const root = document.querySelector<HTMLElement>('[data-floating-cta]');
+  const closeBtn = document.querySelector<HTMLButtonElement>('[data-floating-cta-close]');
+  if (root && closeBtn) {
+    if (sessionStorage.getItem(STORAGE_KEY) !== '1') {
+      root.classList.remove('hidden');
+    }
+    closeBtn.addEventListener('click', () => {
+      sessionStorage.setItem(STORAGE_KEY, '1');
+      root.classList.add('hidden');
+    });
+  }
+</script>

--- a/src/pages/tools/flow-mapper.astro
+++ b/src/pages/tools/flow-mapper.astro
@@ -1,5 +1,6 @@
 ---
 import { Header } from '../../components/header';
+import FloatingCTA from '../../components/ui/floating-cta.astro';
 import { PageHero } from '../../components/ui/page-hero';
 import { FlowMapper } from '../../features/flow-mapper';
 import Layout from '../../layouts/layout.astro';
@@ -247,4 +248,10 @@ import Layout from '../../layouts/layout.astro';
       }
     </script>
   </main>
+  <FloatingCTA
+    href="/contact?source=tool-flow-mapper&intent=floating-stuck&phase=mid"
+    label="迷ったら15分で壁打ち相談"
+    source="tool-flow-mapper"
+    ctaId="floating-stuck"
+  />
 </Layout>

--- a/src/pages/tools/scope-manager.astro
+++ b/src/pages/tools/scope-manager.astro
@@ -1,6 +1,7 @@
 ---
 import { Header } from '../../components/header';
 import { ScopeManager } from '../../components/scope-manager';
+import FloatingCTA from '../../components/ui/floating-cta.astro';
 import { PageHero } from '../../components/ui/page-hero';
 import Layout from '../../layouts/layout.astro';
 ---
@@ -241,4 +242,10 @@ import Layout from '../../layouts/layout.astro';
       }
     </script>
   </main>
+  <FloatingCTA
+    href="/contact?source=tool-scope-manager&intent=floating-stuck&phase=mid"
+    label="スコープ判断を一緒に詰める"
+    source="tool-scope-manager"
+    ctaId="floating-stuck"
+  />
 </Layout>

--- a/src/pages/tools/story-builder.astro
+++ b/src/pages/tools/story-builder.astro
@@ -1,6 +1,7 @@
 ---
 import { Header } from '../../components/header';
 import { StoryBuilder } from '../../components/story-builder';
+import FloatingCTA from '../../components/ui/floating-cta.astro';
 import { PageHero } from '../../components/ui/page-hero';
 import Layout from '../../layouts/layout.astro';
 ---
@@ -218,4 +219,10 @@ import Layout from '../../layouts/layout.astro';
       }
     </script>
   </main>
+  <FloatingCTA
+    href="/contact?source=tool-story-builder&intent=floating-stuck&phase=mid"
+    label="要件のヒアリング相談へ"
+    source="tool-story-builder"
+    ctaId="floating-stuck"
+  />
 </Layout>


### PR DESCRIPTION
## Summary

GA4 で **flow-mapper が 15分滞在 / 3 users / 0 form_submit** と判明。ツールに集中している間はヘッダー直下とフッターの CTA は視界外で、熱量の高いユーザーがそのまま離脱している。画面右下に常時可視の壁打ち相談 CTA を導入する。

## 変更点

- \`src/components/ui/floating-cta.astro\` 新規追加
  - \`fixed bottom-4 right-4\` (sm 以上は \`bottom-6 right-6\`)
  - × ボタンで \`sessionStorage\` に dismiss を保持（次の訪問では再表示）
  - 既存 \`.tool-escape-cta\` クラスを付与し \`trackCtaClick\` 計測に統合
- 3ツールページに source / cta-id を個別に差し込み:
  | ツール | label | URL |
  |---|---|---|
  | flow-mapper | 迷ったら15分で壁打ち相談 | \`?intent=floating-stuck&phase=mid\` |
  | story-builder | 要件のヒアリング相談へ | 同上 |
  | scope-manager | スコープ判断を一緒に詰める | 同上 |

## 既存 CTA との計測区別

- \`intent=tool-stuck&phase=start\` (上部リンク) — 既存
- \`intent=review-request&phase=complete\` (下部完了CTA) — 既存
- \`intent=floating-stuck&phase=mid\` (今回追加) — **どの段階で離脱を救済したかが判別可能**

## Test plan
- [x] \`bun run build\` 成功
- [x] Biome lint pass（編集4ファイル）
- [x] 3ツールで FloatingCTA レンダリング確認 (curl で data-floating-cta / 各 label 検出)
- [x] 200 OK
- [ ] デプロイ後 sm/md/lg ブレークポイントで重なり確認
- [ ] × → sessionStorage 設定 → リロードで非表示確認
- [ ] 1〜2週間後 GA4 で \`floating-stuck\` の cv_card_click 件数を観測

🤖 Generated with [Claude Code](https://claude.com/claude-code)