### PR TITLE
fix(forms): noValidate 除去で空送信をブラウザ側でブロック

### DIFF
--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -116,7 +116,7 @@ const ContactForm = () => {
 
   return (
     <div className="bg-white rounded-[32px] shadow-soft p-8 md:p-12">
-      <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+      <form onSubmit={handleSubmit} className="space-y-6">
         <div>
           <label className="block text-base font-medium text-foreground/80 mb-2" htmlFor="type">
             ご相談内容の種別 <span className="text-destructive">*</span>

--- a/src/components/download-zero-start-form.tsx
+++ b/src/components/download-zero-start-form.tsx
@@ -122,7 +122,7 @@ const DownloadZeroStartForm = () => {
         </p>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+      <form onSubmit={handleSubmit} className="space-y-5">
         <div>
           <label className="block text-sm font-medium text-foreground/80 mb-2" htmlFor="dl-email">
             メールアドレス <span className="text-destructive">*</span>


### PR DESCRIPTION
## Problem
contact-form / download-zero-start-form の \`<form>\` に \`noValidate\` が付いていたため、\`required\` や \`type=\"email\"\` のHTML5バリデーションが効かず、空フォームのままサーバーまで送信される挙動になっていた。

ユーザーから「空でも送れちゃう」報告（実際にはサーバーで弾かれて「メールアドレスを正しく入力してください」が表示される構造）。

## Fix
両フォームから \`noValidate\` を除去。これでブラウザが空送信時にネイティブの検証ツールチップで誘導し、\`/api/contact\` までリクエストが飛ばない。

## Test plan
- [x] Biome ✓
- [ ] CI（このPRで実行）
- [ ] 本番 /contact で空送信→ブラウザのネイティブバリデーションが効くことを確認
- [ ] 本番 /downloads/zero-start でも同様の挙動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)