### PR TITLE
feat(cvr): コンテンツターゲティング改善 -- title/desc + bridge CTA + FAQ

### DIFF
--- a/scripts/patch-add-faq-bzone.mjs
+++ b/scripts/patch-add-faq-bzone.mjs
@@ -1,0 +1,219 @@
+// scripts/patch-add-faq-bzone.mjs
+// B-zone（検討者向け上位記事）にFAQブロックを追加するPATCHスクリプト。
+//
+// 使い方:
+//   node --env-file=.env scripts/patch-add-faq-bzone.mjs                # dry-run
+//   node --env-file=.env scripts/patch-add-faq-bzone.mjs --apply        # 実際にPATCH送信
+//
+// 対象記事（インプレッション順）:
+//   1. requirements-vs-requests (1,262 imp)
+//   2. ai-development-cost-guide (740 imp) — 既にFAQあり、自動SKIP
+//   3. how-to-write-rfp (583 imp) — 既にFAQあり、自動SKIP
+//   4. web-system-cost-by-scale (439 imp)
+//
+// 設計は patch-add-faq.mjs と同一パターン。
+
+import { createClient } from 'microcms-js-sdk';
+
+const APPLY = process.argv.includes('--apply');
+
+const client = createClient({
+  serviceDomain: process.env.MICROCMS_SERVICE_DOMAIN,
+  apiKey: process.env.MICROCMS_API_KEY,
+});
+
+const FAQ_PATCHES = [
+  {
+    slug: 'requirements-vs-requests',
+    introHeading: 'よくある質問（FAQ）',
+    faqs: [
+      {
+        q: '要求定義と要件定義はどちらを先にやるべきですか？',
+        a: '要求定義が先です。要求は「顧客がやりたいこと」、要件は「システムが満たすべき条件」であり、要求を整理しないまま要件に進むと主語が曖昧なドキュメントになります。本記事で解説した通り、要望 → 要求 → 要件の順で具体化していくのが正しい流れです。全体像は<a href="/column/requirements-definition-complete-guide">要件定義の完全ガイド</a>で体系的に解説しています。',
+      },
+      {
+        q: '要件定義書に要求も書いてしまってよいですか？',
+        a: '混在させるべきではありません。要求の主語は「顧客」、要件の主語は「システム」であり、1つのドキュメントに混在すると検証可能性が失われます。要求は<a href="/column/user-story-template-examples">ユーザーストーリー</a>形式で別途整理し、それを受入条件付きの要件文に変換するのがBeekle推奨の進め方です。',
+      },
+      {
+        q: '要求定義がうまくできないとどうなりますか？',
+        a: '再見積もりの多発、スコープクリープ、検収時の衝突という3つの問題が起きます。たとえば「サクサク使える」のような曖昧な要求がそのまま要件として記録されると、完成後に「思っていたものと違う」で再開発になり、見積もりの2倍以上の工数が発生することもあります。<a href="/column/requirements-definition-process">要件定義の進め方</a>で具体的な変換手順を解説しています。',
+      },
+      {
+        q: '要求定義を発注者側で進めるにはどうすればよいですか？',
+        a: 'Beekleが推奨する4ステップがあります。(1) 要求をユーザーストーリー化する、(2) 受入条件を付ける、(3) <a href="/column/ears-requirements-syntax-guide">EARS記法</a>で要件文に変換する、(4) 数値目標を追加する。このプロセスを<a href="/tools/story-builder">ユーザーストーリー作成ツール</a>で実践すると、要求を構造的に整理できます。',
+      },
+    ],
+  },
+  {
+    slug: 'ai-development-cost-guide',
+    introHeading: 'よくある質問（FAQ）',
+    faqs: [
+      {
+        q: '生成AI開発のPoCにはいくらかかりますか？',
+        a: '中堅企業の社内向け検証（PoC）であれば80万～250万円、期間1～2か月が目安です。ただし「動いた」だけでは本番化の判断ができないため、業務担当者と一緒に評価リスト（30～100件）を作り精度を数値で測る作業を必ず含めてください。詳しくは<a href="/column/ai-poc-to-production">PoCから本番化に進める条件</a>を参照してください。',
+      },
+      {
+        q: '生成AI開発の見積もりで注目すべき項目は何ですか？',
+        a: '特に重要なのは「使う生成AIの具体名が書いてあるか」と「月額利用料の試算が出ているか」の2点です。具体名が出てこない、または月額試算がない場合、設計が固まっていない可能性が高いです。本記事の見積もりチェックリスト10項目を<a href="/column/quote-comparison-checklist">見積もり比較チェックリスト</a>と合わせて確認すると抜け漏れを防げます。',
+      },
+      {
+        q: 'API利用料と開発費用は何が違いますか？',
+        a: '開発費用はシステムを構築する一時費用、API利用料はOpenAIやAnthropicに毎月支払う従量課金です。見積もりに「利用料は実費」と書かれている場合、月額がそのまま発注者負担になります。社員100名で1日10回利用の場合、月3万～8万円が目安です。試算が出てこない見積もりは後から請求で揉める典型パターンです。',
+      },
+      {
+        q: '複数社の見積もりを比較するときのポイントは？',
+        a: '発注前に「どのフェーズの予算か」「データ範囲」「成功基準」の3つを言語化してから依頼すると、各社の前提が揃って比較しやすくなります。1社だけ極端に安い見積もりは、評価作業やセキュリティ設計が省かれている可能性があります。<a href="/prooffirst">Beekleのゼロスタート</a>では検証フェーズの費用を作業項目別に分解して開示しています。',
+      },
+    ],
+  },
+  {
+    slug: 'how-to-write-rfp',
+    introHeading: 'よくある質問（FAQ）',
+    faqs: [
+      {
+        q: 'RFPに書くべき必須項目は何ですか？',
+        a: '本記事で解説した10章構成（背景・目的、現状業務、ToBe像、機能要件、非機能要件、システム構成、体制・役割分担、スケジュール、予算感、評価基準）が骨格です。特に「背景・目的」で数値目標、「現状業務」でAsIsフロー、「評価基準」で重み付けを書くことが提案品質を決めます。要件の整理には<a href="/column/requirements-definition-complete-guide">要件定義の完全ガイド</a>が参考になります。',
+      },
+      {
+        q: 'RFPなしでベンダー選定すると何が起きますか？',
+        a: 'ベンダーが「察して」見積もるため提案内容にズレが生じ、追加要望のたびに別途見積もりで予算が膨らみます。社内稟議で「なぜこのベンダーか」を説明する根拠もなく、後半で揉めても判断軸が薄い状態になります。RFPは比較のためだけでなく、発注者の意思を文字に残す装置です。',
+      },
+      {
+        q: 'RFPの評価基準はどう作ればよいですか？',
+        a: '機能適合性・技術力・プロジェクト体制・費用・運用保守の5軸に重み付けして、事前にベンダーに開示するのが効果的です。評価基準が事前に分かっていれば提案の質が揃い、選定後の説明責任も果たしやすくなります。機能要件の優先順位付けには<a href="/tools/scope-manager">スコープ管理ツール</a>が使えます。',
+      },
+      {
+        q: 'RFPは何社に送るのが適切ですか？',
+        a: '3～5社が実務的に妥当です。2社以下では比較軸が少なく、6社以上では評価工数が膨らみます。候補ベンダーの得意領域が読みきれない場合は、RFPの前に軽いRFI（情報提供依頼書）を挟むと選定精度が上がります。ベンダー比較のポイントは<a href="/column/ai-development-vendor-selection">開発会社の選び方</a>も参照してください。',
+      },
+    ],
+  },
+  {
+    slug: 'web-system-cost-by-scale',
+    introHeading: 'よくある質問（FAQ）',
+    faqs: [
+      {
+        q: 'Webシステム開発で予算超過が起きる原因は何ですか？',
+        a: '最も多い原因は要件定義の甘さです。「小さい」と思って雑な要件定義で進めると、想定外の業務が途中で見つかり工数が倍増します。中規模以上ではPO（プロダクトオーナー）不在による意思決定の遅延も典型的です。発注前に<a href="/column/quote-comparison-checklist">見積もり比較チェックリスト</a>で費用の内訳を確認しておくと予算超過のリスクを下げられます。',
+      },
+      {
+        q: '小規模開発と大規模開発の体制はどう違いますか？',
+        a: '小規模（300～800万円）はPM兼エンジニア1名＋開発1～2名で済みますが、大規模（4,000万円以上）はPM・アーキテクト・開発リーダー複数名・QAチーム・SREなど10名以上の体制が必要です。規模に合わない体制で始めると、小規模なら進捗が見えなくなり、大規模ならガバナンス不足で炎上します。',
+      },
+      {
+        q: '開発費用の見積もりを比較するコツはありますか？',
+        a: '同じ「1,000万円」でも、小規模をオーバースペックで作ったのか、中規模を適正に作ったのかで意味が違います。まず本記事の判断軸（利用ユーザー数、画面数、外部連携数、業務複雑さ、非機能要件）で自社プロジェクトの規模を特定し、規模に合った発注スタイルを選んでください。内訳の詳しい読み方は<a href="/column/system-development-cost-breakdown">システム開発費用の内訳ガイド</a>で解説しています。',
+      },
+      {
+        q: '運用・保守コストはどの程度見込めばよいですか？',
+        a: '開発規模によりますが、初期費用の15～25%程度を年間の運用・保守費として見込むのが一般的です。モニタリング、ログ管理、デプロイ自動化、セキュリティパッチ適用、障害対応が主な内訳です。RFP段階で運用フェーズの体制と費用を明記しておくと、リリース後に「保守契約が決まっていない」事態を防げます。見積もりの全体像は<a href="/column/estimate-complete-guide">見積もり完全ガイド</a>を参照してください。',
+      },
+    ],
+  },
+];
+
+function buildFaqHtml(introHeading, faqs) {
+  const lines = [`<h2>${introHeading}</h2>`];
+  for (const { q, a } of faqs) {
+    lines.push(`<h2>Q. ${q}</h2>`);
+    lines.push(`<p>A. ${a}</p>`);
+  }
+  return `\n${lines.join('\n')}\n`;
+}
+
+function hasExistingFaq(html) {
+  return (
+    /<h[23][^>]*>\s*よくある質問/.test(html) ||
+    /<h[23][^>]*>Q\d*\.?\s/.test(html) ||
+    /<p>\s*<strong>\s*Q\.\s/.test(html) ||
+    /<p>\s*Q\.\s[\s\S]{0,200}A\.\s/.test(html)
+  );
+}
+
+function insertFaqBeforeFinalCta(content, faqBlock) {
+  // {{CONTACT_CTA}} または {{ZERO_START_CTA}} の最後の出現の直前に挿入
+  const ctaRegex = /<p>\s*\{\{(?:CONTACT_CTA|ZERO_START_CTA)\}\}\s*<\/p>/g;
+  const matches = [...content.matchAll(ctaRegex)];
+  if (matches.length === 0) {
+    // CTA マーカーが無い場合は末尾に追加
+    return content + faqBlock;
+  }
+  const last = matches[matches.length - 1];
+  const idx = last.index;
+  return `${content.substring(0, idx)}${faqBlock}\n${content.substring(idx)}`;
+}
+
+async function processOne(patch) {
+  const { slug, introHeading, faqs } = patch;
+  console.log(`\n========== ${slug} ==========`);
+
+  let column;
+  try {
+    column = await client.get({
+      endpoint: 'columns',
+      contentId: slug,
+      queries: { fields: 'id,title,content' },
+    });
+  } catch (err) {
+    console.error(`  ERROR: fetch failed: ${err.message}`);
+    return { slug, status: 'fetch_failed' };
+  }
+
+  if (column.id !== slug) {
+    console.error(`  STOP: ID mismatch expected=${slug} actual=${column.id}`);
+    return { slug, status: 'id_mismatch' };
+  }
+  console.log(`  TITLE: ${column.title}`);
+
+  if (hasExistingFaq(column.content)) {
+    console.log('  SKIP: FAQ block already exists');
+    return { slug, status: 'skipped_has_faq' };
+  }
+
+  const faqHtml = buildFaqHtml(introHeading, faqs);
+  const newContent = insertFaqBeforeFinalCta(column.content, faqHtml);
+
+  console.log(
+    `  ADD ${faqs.length} FAQs (content ${column.content.length} -> ${newContent.length}, +${newContent.length - column.content.length})`
+  );
+
+  // Show preview of inserted FAQ
+  console.log('  --- FAQ PREVIEW ---');
+  console.log(faqHtml.substring(0, 600));
+  if (faqHtml.length > 600) console.log('  ... (truncated)');
+  console.log('  --- END PREVIEW ---');
+
+  if (!APPLY) {
+    console.log('  DRY-RUN: use --apply to send PATCH');
+    return { slug, status: 'dry_run' };
+  }
+
+  try {
+    await client.update({ endpoint: 'columns', contentId: slug, content: { content: newContent } });
+  } catch (err) {
+    console.error(`  PATCH FAILED: ${err.message}`);
+    return { slug, status: 'patch_failed' };
+  }
+  console.log('  PATCH OK');
+
+  // Verify
+  const verify = await client.get({
+    endpoint: 'columns',
+    contentId: slug,
+    queries: { fields: 'id,content' },
+  });
+  const ok = hasExistingFaq(verify.content);
+  console.log(`  VERIFY: FAQ block detected = ${ok}`);
+  return { slug, status: ok ? 'applied' : 'applied_but_verify_failed' };
+}
+
+const results = [];
+for (const patch of FAQ_PATCHES) {
+  results.push(await processOne(patch));
+}
+
+console.log(`\n========== Summary (${APPLY ? 'APPLIED' : 'DRY-RUN ONLY'}) ==========`);
+for (const r of results) {
+  console.log(`  ${r.slug.padEnd(36)} ${r.status}`);
+}

--- a/scripts/patch-engineer-cta.mjs
+++ b/scripts/patch-engineer-cta.mjs
@@ -1,0 +1,158 @@
+/**
+ * エンジニア向け記事 (Gherkin/EARS) の末尾ハードコードCTAを
+ * {{BRIDGE_CTA}} マーカーに差し替える。
+ *
+ * これらの記事は {{CONTACT_CTA}} マーカーではなく、直書きの
+ * <h2>...CTA見出し...</h2><p>...誘導文...</p><p><a href="/contact">...</a>...</p>
+ * パターンで CTA を持っている。このスクリプトはそのブロックを検出し
+ * {{BRIDGE_CTA}} に置き換える。
+ *
+ * 対象記事:
+ *   - gherkin-bdd-introduction
+ *   - ears-requirements-syntax-guide
+ *   - ears-gherkin-workflow
+ *
+ * 使い方:
+ *   node --env-file=.env scripts/patch-engineer-cta.mjs          # dry-run
+ *   node --env-file=.env scripts/patch-engineer-cta.mjs --apply  # 実際に PATCH
+ */
+import 'dotenv/config';
+import { createClient } from 'microcms-js-sdk';
+
+const apply = process.argv.includes('--apply');
+const dryRun = !apply;
+
+const client = createClient({
+  serviceDomain: process.env.MICROCMS_SERVICE_DOMAIN,
+  apiKey: process.env.MICROCMS_API_KEY,
+});
+
+/**
+ * 各記事ごとに、置換対象のCTAブロックを正規表現で定義。
+ * 関連記事セクションは残し、CTAの h2 + 本文 + リンク段落だけを差し替える。
+ */
+const TARGETS = [
+  {
+    slug: 'gherkin-bdd-introduction',
+    // <h2 id="h794b7c1204">BDDで現場と開発を一直線にしたい方へ</h2>
+    // <p>Beekleでは...支援しています。</p>
+    // <p><a href="/contact">無料相談を予約する</a> / <a href="/prooffirst">ゼロスタートを詳しく見る</a></p>
+    pattern:
+      /<h2 id="h794b7c1204">BDD[^<]*<\/h2><p>Beekle[^<]*<\/p><p><a href="\/contact">[^<]*<\/a>[^<]*<a href="\/prooffirst">[^<]*<\/a><\/p>/,
+  },
+  {
+    slug: 'ears-requirements-syntax-guide',
+    // <h2 id="h340c799757">要件記述でお困りなら</h2>
+    // <p>複雑な業務要件をEARSで整理する支援も行っています。</p>
+    // <p><a href="/contact">無料相談を予約する</a> / <a href="/tools/story-builder">Story Builder を試す</a></p>
+    pattern:
+      /<h2 id="h340c799757">要件記述[^<]*<\/h2><p>[^<]*支援も行っています。<\/p><p><a href="\/contact">[^<]*<\/a>[^<]*<a href="\/tools\/story-builder">[^<]*<\/a><\/p>/,
+  },
+  {
+    slug: 'ears-gherkin-workflow',
+    // <h2 id="ha784afc1b2">このワークフローを試してみたい方へ</h2>
+    // <p><a href="/contact">無料相談を予約する</a> / <a href="/prooffirst">ゼロスタートを詳しく見る</a></p>
+    pattern:
+      /<h2 id="ha784afc1b2">この[^<]*<\/h2><p><a href="\/contact">[^<]*<\/a>[^<]*<a href="\/prooffirst">[^<]*<\/a><\/p>/,
+  },
+];
+
+const BRIDGE_MARKER = '{{BRIDGE_CTA}}';
+
+console.log(`Mode: ${dryRun ? 'DRY-RUN (no API writes)' : 'APPLY (PATCH to MicroCMS)'}`);
+console.log(`Targets: ${TARGETS.length} articles`);
+console.log('---');
+
+let succeeded = 0;
+const errors = [];
+const skipped = [];
+
+for (const { slug, pattern } of TARGETS) {
+  console.log(`\n[${slug}]`);
+
+  let article;
+  try {
+    article = await client.get({
+      endpoint: 'columns',
+      contentId: slug,
+      queries: { fields: 'id,title,content' },
+    });
+  } catch (e) {
+    const msg = `${slug}: fetch failed - ${e.message}`;
+    console.error(`   NG: ${msg}`);
+    errors.push(msg);
+    continue;
+  }
+
+  console.log(`   title: ${article.title}`);
+  const content = article.content || '';
+  console.log(`   content length: ${content.length} chars`);
+
+  // Check if already has bridge marker
+  const hasBridgeCta = /\{\{BRIDGE_CTA\}\}/.test(content);
+  if (hasBridgeCta) {
+    console.log('   SKIP: already has {{BRIDGE_CTA}}');
+    skipped.push(slug);
+    continue;
+  }
+
+  // Find hardcoded CTA block
+  const match = content.match(pattern);
+  if (!match) {
+    console.log('   SKIP: hardcoded CTA block not found (pattern mismatch)');
+    console.log('   hint: the article may have been edited since this script was written');
+    skipped.push(slug);
+    continue;
+  }
+
+  console.log(`   found CTA block (${match[0].length} chars):`);
+  const preview = match[0].length > 120 ? `${match[0].slice(0, 120)}...` : match[0];
+  console.log(`     ${preview}`);
+
+  const newContent = content.replace(pattern, BRIDGE_MARKER);
+
+  if (newContent === content) {
+    console.log('   SKIP: content unchanged after replacement');
+    skipped.push(slug);
+    continue;
+  }
+
+  console.log('   replacement: hardcoded CTA -> {{BRIDGE_CTA}}');
+  console.log(
+    `   new content length: ${newContent.length} chars (delta: ${newContent.length - content.length})`
+  );
+
+  if (dryRun) {
+    console.log('   OK: would PATCH (dry-run)');
+    succeeded++;
+    continue;
+  }
+
+  try {
+    await client.update({
+      endpoint: 'columns',
+      contentId: slug,
+      content: { content: newContent },
+    });
+    console.log('   OK: PATCH applied');
+    succeeded++;
+  } catch (e) {
+    const msg = `${slug}: ${e.message}`;
+    console.error(`   NG: ${msg}`);
+    errors.push(msg);
+  }
+}
+
+console.log('\n========================================');
+console.log(`${dryRun ? 'plan' : 'patched'}: ${succeeded}/${TARGETS.length}`);
+if (skipped.length > 0) {
+  console.log(`skipped: ${skipped.length} (${skipped.join(', ')})`);
+}
+if (errors.length > 0) {
+  console.log(`errors: ${errors.length}`);
+  for (const e of errors) console.log(`   - ${e}`);
+  process.exit(1);
+}
+if (dryRun) {
+  console.log('\nThis was a dry run. Re-run with --apply to actually PATCH.');
+}

--- a/scripts/patch-title-desc.mjs
+++ b/scripts/patch-title-desc.mjs
@@ -1,0 +1,144 @@
+/**
+ * B-zone 記事の title / description を PATCH して CTR を改善する。
+ * content (本文) は一切触らない。
+ *
+ * 使い方:
+ *   node --env-file=.env scripts/patch-title-desc.mjs          # dry-run
+ *   node --env-file=.env scripts/patch-title-desc.mjs --apply  # 実際に PATCH
+ */
+import 'dotenv/config';
+import { createClient } from 'microcms-js-sdk';
+
+const apply = process.argv.includes('--apply');
+const dryRun = !apply;
+
+const client = createClient({
+  serviceDomain: process.env.MICROCMS_SERVICE_DOMAIN,
+  apiKey: process.env.MICROCMS_API_KEY,
+});
+
+// --- PATCH 対象 -----------------------------------------------------------
+// title: null のときは変更しない（現行維持）
+const PATCHES = [
+  {
+    slug: 'requirements-vs-requests',
+    title: '要求定義と要件定義の違い｜混同が手戻りを招く3つの判別軸と正しい変換手順',
+    description:
+      '要求定義と要件定義を混同すると、開発着手後に「これじゃない」の手戻りが発生します。主語・抽象度・検証可能性の3軸で判別し、要求を要件へ変換する手順を失敗実例つきで解説。発注担当・PM必読。',
+  },
+  {
+    slug: 'web-system-cost-by-scale',
+    title: 'Webシステム開発の費用相場｜予算超過しないための規模別チェックポイント',
+    description:
+      '小規模300万〜大規模4,000万超。Webシステム開発費用は見積もり時の想定と実際の乖離が最大の落とし穴。体制・追加費用・運用コストまで規模別に分解し、予算超過を防ぐための判断軸を提示。',
+  },
+  {
+    slug: 'ai-development-cost-guide',
+    title: '生成AI開発の費用相場｜PoC→本番運用の内訳と見積もり比較のポイント',
+    description:
+      '生成AI開発はPoC50万〜本番運用1,000万超と幅が大きい。検証・試作・本番の3段階で費用構造が変わる理由と、複数社の見積もりで必ず確認すべき比較ポイントを発注担当者向けに整理。',
+  },
+  {
+    slug: 'mvp-development-guide',
+    title: 'MVP開発とは｜PoC・プロトタイプとの違い・費用相場・進め方を発注者目線で解説',
+    description:
+      'MVP・PoC・プロトタイプ開発の違いと使い分け、費用の目安、発注時の注意点を1記事で整理。「動くものを先に見てから判断したい」発注者に向けて、ゼロスタート開発を含む実践的な選択肢を提示。',
+  },
+  {
+    slug: 'quote-comparison-checklist',
+    title: null, // 現行タイトル維持
+    description:
+      'システム開発の見積書を総額だけで比較すると、安い方に飛びついて追加費用で結局高くつく。人月単価・工数根拠・保守費用など13のチェック項目で見積もりの「罠」を洗い出す方法を具体例つきで解説。',
+  },
+];
+
+// --------------------------------------------------------------------------
+
+console.log(`Mode: ${dryRun ? 'DRY-RUN (no API writes)' : 'APPLY (PATCH title/description)'}`);
+console.log(`Targets: ${PATCHES.length} articles\n`);
+
+let succeeded = 0;
+const errors = [];
+
+for (const patch of PATCHES) {
+  const { slug, title: newTitle, description: newDesc } = patch;
+
+  // 1. 現在のデータを取得
+  let current;
+  try {
+    current = await client.get({
+      endpoint: 'columns',
+      contentId: slug,
+      queries: { fields: 'id,title,description' },
+    });
+  } catch (e) {
+    const msg = `${slug}: fetch failed - ${e.message}`;
+    console.error(`[NG] ${msg}`);
+    errors.push(msg);
+    continue;
+  }
+
+  // 2. diff 表示
+  console.log(`--- ${slug} ---`);
+
+  if (newTitle !== null) {
+    const changed = current.title !== newTitle;
+    console.log(`  title (old): ${current.title}`);
+    console.log(`  title (new): ${newTitle}`);
+    console.log(`  title changed: ${changed ? 'YES' : 'no (identical)'}`);
+  } else {
+    console.log(`  title: SKIP (keep current: ${current.title})`);
+  }
+
+  const oldDesc = current.description || '(empty)';
+  console.log(`  desc  (old): ${oldDesc}`);
+  console.log(`  desc  (new): ${newDesc}`);
+  console.log(`  desc changed: ${oldDesc !== newDesc ? 'YES' : 'no (identical)'}`);
+
+  // 3. PATCH 内容を組み立て（変更があるフィールドのみ）
+  const content = {};
+  if (newTitle !== null && current.title !== newTitle) {
+    content.title = newTitle;
+  }
+  if ((current.description || '') !== newDesc) {
+    content.description = newDesc;
+  }
+
+  if (Object.keys(content).length === 0) {
+    console.log('  -> nothing to update (already identical)\n');
+    succeeded++;
+    continue;
+  }
+
+  if (dryRun) {
+    console.log(`  -> would PATCH fields: [${Object.keys(content).join(', ')}] (dry-run)\n`);
+    succeeded++;
+    continue;
+  }
+
+  // 4. PATCH 実行
+  try {
+    await client.update({
+      endpoint: 'columns',
+      contentId: slug,
+      content,
+    });
+    console.log(`  -> PATCH applied: [${Object.keys(content).join(', ')}]\n`);
+    succeeded++;
+  } catch (e) {
+    const msg = `${slug}: PATCH failed - ${e.message}`;
+    console.error(`  -> [NG] ${msg}\n`);
+    errors.push(msg);
+  }
+}
+
+console.log('========================================');
+console.log(`${dryRun ? 'plan' : 'patched'}: ${succeeded}/${PATCHES.length}`);
+if (errors.length > 0) {
+  console.log(`errors: ${errors.length}`);
+  for (const e of errors) console.log(`   - ${e}`);
+  process.exit(1);
+}
+if (dryRun) {
+  console.log('\nThis was a dry run. Re-run with --apply to actually PATCH.');
+}

--- a/src/lib/column-visuals.ts
+++ b/src/lib/column-visuals.ts
@@ -506,6 +506,22 @@ const EARS_TO_GHERKIN_MAP = `<figure class="cv-card cv-card-full">
   </div>
 </figure>`;
 
+function buildBridgeCta(source: string): string {
+  // Zero Start導線: エンジニア向け記事 → 要件定義コンテンツ → ゼロスタート
+  return `<figure class="cv-card">
+  <figcaption class="cv-card-header cv-header-primary">この記事の手法をプロジェクトに活かす</figcaption>
+  <div class="cv-card-body">
+    <p>EARS記法やGherkinを実際のプロジェクトで使うには、上流の要件整理が鍵になります。</p>
+    <ul>
+      <li><a href="/column/requirements-definition-complete-guide">要件定義の進め方・完全ガイド</a> -- 上流工程の全体像と実務テクニック</li>
+      <li><a href="/column/requirements-vs-requests">要求定義と要件定義の違い</a> -- 混同が手戻りを招く3つの判別軸</li>
+      <li><a href="/column/how-to-write-rfp">失敗しないRFPの作り方</a> -- ベンダー選定に必要な提案依頼書の書き方</li>
+    </ul>
+    <p>要件定義から開発まで一気通貫で進めたい場合は、初期費用0円で動くプロトタイプから始められる<a href="/prooffirst?source=${encodeURIComponent(source)}&intent=bridge-engineer">ゼロスタート開発</a>もご検討ください。</p>
+  </div>
+</figure>`;
+}
+
 function buildContactCta(source: string, intent: string): string {
   const href = `/contact?source=${encodeURIComponent(source)}&intent=${encodeURIComponent(intent)}`;
   return `<figure class="cv-card">
@@ -513,6 +529,17 @@ function buildContactCta(source: string, intent: string): string {
   <div class="cv-card-body">
     <p>Beekleでは、生成AI／CDP／業務システムの企画・要件定義・開発・運用までワンストップで支援しています。「何を作れば成功か」の整理、検証フェーズの設計、本番化判断まで、発注側の判断材料が揃うように伴走します。費用感の概算だけでも歓迎です。</p>
     <p style="text-align:center;margin-top:1.25rem;"><a href="${href}" data-cta-source="${source}" data-cta-id="contact-${intent}">お問い合わせはこちら</a></p>
+  </div>
+</figure>`;
+}
+
+function buildZeroStartCta(source: string, intent: string): string {
+  const href = `/downloads/zero-start?source=${encodeURIComponent(source)}&intent=${encodeURIComponent(intent)}`;
+  return `<figure class="cv-card">
+  <figcaption class="cv-card-header cv-header-primary">初期費用0円のMVP開発・PoC開発・プロトタイプ開発を発注前に試せる</figcaption>
+  <div class="cv-card-body">
+    <p>Beekleの「ゼロスタート開発」は、初期費用0円で動くプロトタイプを体験してから本契約を判断できるMVP開発・PoC開発・プロトタイプ開発のサービスです。見積書とPowerPointの提案だけで判断するのではなく、実際に動くものを触って「現場で使えるか」「投資に見合うか」を確認したうえで契約に進めます。仕組み・対象企業・進行プロセス・実例ベースの導入ステップをまとめたサービス資料を無料配布しています。</p>
+    <p style="text-align:center;margin-top:1.25rem;"><a href="${href}" data-cta-source="${source}" data-cta-id="zero-start-${intent}">サービス資料を無料ダウンロード</a></p>
   </div>
 </figure>`;
 }
@@ -587,12 +614,31 @@ export function renderColumnVisuals(html: string, ctx?: ColumnVisualContext): st
   }
 
   if (ctx) {
-    const dynamicMarkers: Array<[string, string]> = [
+    const contactMarkers: Array<[string, string]> = [
       ['CONTACT_CTA', 'article-final'],
       ['CONTACT_CTA_MID', 'article-mid'],
     ];
-    for (const [key, intent] of dynamicMarkers) {
+    for (const [key, intent] of contactMarkers) {
       const visual = buildContactCta(ctx.source, intent);
+      const wrapped = new RegExp(`<p>\\s*\\{\\{${key}\\}\\}\\s*</p>`, 'g');
+      const bare = new RegExp(`\\{\\{${key}\\}\\}`, 'g');
+      result = result.replace(wrapped, visual).replace(bare, visual);
+    }
+
+    const zeroStartMarkers: Array<[string, string]> = [
+      ['ZERO_START_CTA', 'article-final'],
+      ['ZERO_START_CTA_MID', 'article-mid'],
+    ];
+    for (const [key, intent] of zeroStartMarkers) {
+      const visual = buildZeroStartCta(ctx.source, intent);
+      const wrapped = new RegExp(`<p>\\s*\\{\\{${key}\\}\\}\\s*</p>`, 'g');
+      const bare = new RegExp(`\\{\\{${key}\\}\\}`, 'g');
+      result = result.replace(wrapped, visual).replace(bare, visual);
+    }
+
+    const bridgeMarkers: Array<[string, string]> = [['BRIDGE_CTA', 'bridge']];
+    for (const [key, _intent] of bridgeMarkers) {
+      const visual = buildBridgeCta(ctx.source);
       const wrapped = new RegExp(`<p>\\s*\\{\\{${key}\\}\\}\\s*</p>`, 'g');
       const bare = new RegExp(`\\{\\{${key}\\}\\}`, 'g');
       result = result.replace(wrapped, visual).replace(bare, visual);

--- a/src/pages/column/[...slug].astro
+++ b/src/pages/column/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { Renderer, marked } from 'marked';
 import { Header } from '../../components/header';
+import AuthorByline from '../../components/seo/author-byline.astro';
 import JsonLd from '../../components/seo/json-ld.astro';
 import Layout from '../../layouts/layout.astro';
 import { getCategoryCta } from '../../lib/column-cta-mapping';
@@ -18,6 +19,16 @@ import { type TocItem, slugify } from '../../lib/toc';
 export const prerender = false;
 const { slug } = Astro.params;
 const columnId = slug as string;
+
+// SEOカニバリ統合: 旧スラッグから統合先へ301リダイレクト
+const columnRedirects: Record<string, string> = {
+  'project-management-01': '/column/requirements-definition-process',
+  'system-development-cost-market': '/column/web-system-cost-by-scale',
+  'system-estimate-uncertainty': '/column/system-estimate-validity',
+};
+if (columnId in columnRedirects) {
+  return Astro.redirect(columnRedirects[columnId], 301);
+}
 
 // Cloudflare Pages SSR: ランタイム環境変数を取得
 const runtime = (Astro.locals as { runtime?: { env?: MicroCMSEnv } }).runtime;
@@ -84,6 +95,20 @@ let htmlContent = marked(column.content || '') as string;
 // 記事内の {{MARKER}} ビジュアルプレースホルダーを差し込みHTMLに置換
 // CONTACT_CTA / CONTACT_CTA_MID は記事固有 source で動的生成
 htmlContent = renderColumnVisuals(htmlContent, { source: `column-${columnId}` });
+
+// CTA pill 化: <p> 内が空白＋単独 <a href="/contact..."> のみのときだけ cv-cta-button クラスを付与する。
+// CSS の :only-child は要素兄弟しか見ないため、テキストに挟まれた inline link も誤マッチしてしまう（FAQ 内の
+// 「Beekleの<a href="/prooffirst">ゼロスタート</a>」のような表現がピル化される）。post-process で <p>↔<a>↔</p>
+// の間に他テキストが無いケースに限定してクラスを付ける。
+htmlContent = htmlContent.replace(
+  /<p([^>]*)>\s*(<a\s[^>]*href="\/contact[^"]*"[^>]*>[^<]+<\/a>)\s*<\/p>/g,
+  (_match, pAttrs, anchor) => {
+    const withClass = / class="/.test(anchor)
+      ? anchor.replace(/class="([^"]*)"/, 'class="$1 cv-cta-button"')
+      : anchor.replace('<a ', '<a class="cv-cta-button" ');
+    return `<p${pAttrs}>${withClass}</p>`;
+  }
+);
 
 // HTML直書きの<h2>/<h3>にもidを付与し目次データを収集（リッチエディタHTML対応）
 htmlContent = htmlContent.replace(/<h([23])>([^<]+)<\/h[23]>/g, (_match, level, text) => {
@@ -245,20 +270,25 @@ const subContactHref = `/contact?source=${encodeURIComponent(ctaSource)}&intent=
     {/* Article Header */}
     <section class="py-12 md:py-16 bg-gradient-to-br from-primary-50 to-primary-100">
       <div class="container mx-auto px-6 md:px-8 max-w-4xl">
-        {/* Meta Info */}
-        <div class="flex flex-wrap items-center gap-3 mb-6">
-          {isPillar && (
+        {isPillar && (
+          <div class="mb-6">
             <span class="inline-flex items-center px-3 py-1 bg-primary-500 text-white text-xs font-bold rounded-full">
               完全ガイド
             </span>
-          )}
-          <span class="text-sm text-gray-600">{frontmatter.publishedAt}</span>
-        </div>
+          </div>
+        )}
 
         {/* Title */}
-        <h1 class="text-3xl md:text-5xl font-bold text-gray-900 leading-tight">
+        <h1 class="text-3xl md:text-5xl font-bold text-gray-900 leading-tight mb-6">
           {frontmatter.title}
         </h1>
+
+        {/* Author Byline (compact) */}
+        <AuthorByline
+          variant="compact"
+          publishedAt={column.publishedAt}
+          updatedAt={column.updatedAt}
+        />
       </div>
     </section>
 
@@ -292,13 +322,20 @@ const subContactHref = `/contact?source=${encodeURIComponent(ctaSource)}&intent=
     )}
 
     {/* Article Content */}
-    <article class="py-16 md:py-24 bg-white">
+    <article class="py-16 md:py-20 bg-white">
       <div class="container mx-auto px-6 md:px-12 max-w-3xl">
         <div class="markdown-content">
           <Fragment set:html={htmlContent} />
         </div>
       </div>
     </article>
+
+    {/* Author Bio (detailed) - E-E-A-T signals for AI search and humans */}
+    <section class="pb-16 md:pb-20 bg-white">
+      <div class="container mx-auto px-6 md:px-12 max-w-3xl">
+        <AuthorByline variant="detailed" />
+      </div>
+    </section>
 
     {/* クラスター記事 → ピラー記事への戻りリンク */}
     {pillarColumn && (
@@ -797,22 +834,19 @@ const subContactHref = `/contact?source=${encodeURIComponent(ctaSource)}&intent=
     margin-bottom: 32px; /* 8 × 4 */
   }
 
-  /* CTAボタンスタイル: <p> の唯一の子になっている時だけ pill 化（インラインの普通のリンクには適用しない） */
-  .markdown-content :global(p > a[href^="/prooffirst"]:only-child),
-  .markdown-content :global(p > a[href^="/contact"]:only-child) {
+  /* CTAボタン pill 化: post-process で <p> 直下の単独 <a href="/contact..."> のみに cv-cta-button クラスが付与される */
+  .markdown-content :global(a.cv-cta-button) {
     @apply inline-flex items-center bg-gradient-to-r from-primary-500 to-primary-600 text-white font-bold rounded-full no-underline;
     padding: 12px 24px;  /* 上下12px (1.5×8), 左右24px (3×8) */
     transition: all 0.3s ease;
     border-bottom: none;
   }
 
-  .markdown-content :global(p > a[href^="/prooffirst"]:only-child)::after,
-  .markdown-content :global(p > a[href^="/contact"]:only-child)::after {
+  .markdown-content :global(a.cv-cta-button)::after {
     content: none;
   }
 
-  .markdown-content :global(p > a[href^="/prooffirst"]:only-child:hover),
-  .markdown-content :global(p > a[href^="/contact"]:only-child:hover) {
+  .markdown-content :global(a.cv-cta-button:hover) {
     @apply shadow-xl;
     transform: translateY(-2px);
   }


### PR DESCRIPTION
## Summary
- B-zone title/desc改善 5記事: requirements-vs-requests(1,262imp/CTR0.5%)等の発注者向け記事を結論型titleに書き換え
- A-zone bridge CTA 3記事: Gherkin/EARS記事の直球営業CTAを要件定義コンテンツ導線+ゼロスタートに差替え
- B-zone FAQ追加 2記事: requirements-vs-requests, web-system-cost-by-scaleにFAQPage構造化データ追加

## 背景
GA4+SC分析でOrganic SearchのKey Events=0件。Gherkin/EARS 3記事が全クリックの44%を占めるがエンジニア流入でCVに繋がっていない。発注者向け記事はimp高いがtitle/descでクリックを取れていない。

## Test plan
- [x] dev serverでbridge CTA表示確認（要件定義ガイド3本+ゼロスタート導線）
- [x] FAQPage構造化データ確認（requirements-vs-requests: 4 Questions）
- [x] MicroCMS PATCH適用済み（title/desc 5記事、CTA 3記事、FAQ 2記事）
- [ ] 本番デプロイ後にbridge CTAが正しくレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)