### PR TITLE
fix(analytics): GA4トラッキング復旧

### DIFF
--- a/src/components/analytics/ga4.astro
+++ b/src/components/analytics/ga4.astro
@@ -1,17 +1,19 @@
 ---
 // Google Analytics 4 トラッキングコード
-const GA_MEASUREMENT_ID = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
+// import.meta.env はビルド時のみ有効。Cloudflare Pages のビルド環境に
+// PUBLIC_GA_MEASUREMENT_ID が設定されていないとタグごと消えるため、
+// TURNSTILE_SITE_KEY と同じく公開値はハードコードフォールバックで保証する。
+const runtime = (Astro.locals as { runtime?: { env?: { PUBLIC_GA_MEASUREMENT_ID?: string } } }).runtime;
+const GA_MEASUREMENT_ID = runtime?.env?.PUBLIC_GA_MEASUREMENT_ID
+  ?? import.meta.env.PUBLIC_GA_MEASUREMENT_ID
+  ?? 'G-R7BXGC7XN6';
 ---
 
-{GA_MEASUREMENT_ID && (
-  <>
-    <!-- Google tag (gtag.js) -->
-    <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}></script>
-    <script is:inline define:vars={{ GA_MEASUREMENT_ID }}>
-      window.dataLayer = window.dataLayer || [];
-      window.gtag = window.gtag || function () { window.dataLayer.push(arguments); };
-      window.gtag('js', new Date());
-      window.gtag('config', GA_MEASUREMENT_ID);
-    </script>
-  </>
-)}
+<!-- Google tag (gtag.js) -->
+<script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}></script>
+<script is:inline define:vars={{ GA_MEASUREMENT_ID }}>
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = window.gtag || function () { window.dataLayer.push(arguments); };
+  window.gtag('js', new Date());
+  window.gtag('config', GA_MEASUREMENT_ID);
+</script>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,10 @@ name = "website"
 compatibility_date = "2025-04-01"
 pages_build_output_dir = "./dist"
 
+[vars]
+PUBLIC_GA_MEASUREMENT_ID = "G-R7BXGC7XN6"
+TURNSTILE_SITE_KEY = "0x4AAAAAADHmRrTyQk-jx5-X"
+
 [[kv_namespaces]]
 binding = "RATE_LIMIT"
 id = "9d7191f03fe84b3f90f14252e5e3d7bd"


### PR DESCRIPTION
## Summary
- GA4が5/7〜5/26の約20日間、本番で完全停止していた
- 原因: `ga4.astro` が `import.meta.env.PUBLIC_GA_MEASUREMENT_ID` のみに依存 → `.env` は `.gitignore` → Cloudflare Pages ビルド環境に変数なし → タグ丸ごとスキップ
- 修正: `runtime.env` → `import.meta.env` → ハードコード `G-R7BXGC7XN6` の3段フォールバック（TURNSTILE_SITE_KEY と同パターン）
- `wrangler.toml` `[vars]` に公開値を追加

## Test plan
- [x] `bun run build` 成功
- [x] ビルド出力に `G-R7BXGC7XN6` 含まれること確認
- [x] dev サーバーの HTML に gtag スクリプト出力確認
- [ ] デプロイ後 `curl -s https://beekle.jp/ | grep gtag` で本番確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)