### PR TITLE
fix(columns): インラインリンクのピル化CSSを修正

### DIFF
--- a/src/pages/column/[...slug].astro
+++ b/src/pages/column/[...slug].astro
@@ -797,22 +797,19 @@ const subContactHref = `/contact?source=${encodeURIComponent(ctaSource)}&intent=
     margin-bottom: 32px; /* 8 × 4 */
   }
 
-  /* CTAボタンスタイル: <p> の唯一の子になっている時だけ pill 化（インラインの普通のリンクには適用しない） */
-  .markdown-content :global(p > a[href^="/prooffirst"]:only-child),
-  .markdown-content :global(p > a[href^="/contact"]:only-child) {
+  /* CTAボタン pill 化: post-process で <p> 直下の単独 <a href="/contact..."> のみに cv-cta-button クラスが付与される */
+  .markdown-content :global(a.cv-cta-button) {
     @apply inline-flex items-center bg-gradient-to-r from-primary-500 to-primary-600 text-white font-bold rounded-full no-underline;
-    padding: 12px 24px;  /* 上下12px (1.5×8), 左右24px (3×8) */
+    padding: 12px 24px;
     transition: all 0.3s ease;
     border-bottom: none;
   }
 
-  .markdown-content :global(p > a[href^="/prooffirst"]:only-child)::after,
-  .markdown-content :global(p > a[href^="/contact"]:only-child)::after {
+  .markdown-content :global(a.cv-cta-button)::after {
     content: none;
   }
 
-  .markdown-content :global(p > a[href^="/prooffirst"]:only-child:hover),
-  .markdown-content :global(p > a[href^="/contact"]:only-child:hover) {
+  .markdown-content :global(a.cv-cta-button:hover) {
     @apply shadow-xl;
     transform: translateY(-2px);
   }


### PR DESCRIPTION
## Summary
- `p>a[href^="/prooffirst"]:only-child` CSS ルールが本文中のインラインリンクをピル化していた
- `:only-child` はテキストノード兄弟を無視するため、テキストに挟まれた `<a>` でも発火する
- `a.cv-cta-button` クラスベースに統一、post-process で付与されたリンクのみピル化

## Test plan
- [x] ビルド成功、compiled CSS に `:only-child` ルールなし
- [ ] https://beekle.jp/column/ai-training-data-quality でインラインリンクがテキストリンクとして表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)