### PR TITLE
feat: 事例集・サービスLPに資料DL導線を追加し流入元を計測

### DIFF
--- a/src/components/download-zero-start-form.tsx
+++ b/src/components/download-zero-start-form.tsx
@@ -56,8 +56,21 @@ const DownloadZeroStartForm = ({ sitekey }: DownloadZeroStartFormProps) => {
       PHASE_OPTIONS.find((o) => o.value === phaseValue)?.label || phaseValue || '未選択';
     const note = String(formData.get('note') || '').trim();
 
+    // 流入元ページ（CTAの ?ref=... ）をリード通知とGA4に反映する
+    const rawRef = new URLSearchParams(window.location.search).get('ref') || '';
+    const ref = rawRef.replace(/[^a-zA-Z0-9-]/g, '').slice(0, 40);
+    const refLabel = ref
+      ? ref === 'case-studies'
+        ? '導入事例ページ'
+        : ref.startsWith('services-')
+          ? `サービスページ（${ref.slice('services-'.length)}）`
+          : ref
+      : '';
+    const source = ref ? `download-zero-start-${ref}` : 'download-zero-start';
+
+    const refBlock = refLabel ? `\n流入元: ${refLabel}` : '';
     const noteBlock = note ? `\nご質問・補足:\n${note}` : '※ご質問・補足はありません';
-    const message = `【ゼロスタート開発 サービスデックDL】\n検討段階: ${phaseLabel}\n${noteBlock}`;
+    const message = `【ゼロスタート開発 サービスデックDL】\n検討段階: ${phaseLabel}${refBlock}\n${noteBlock}`;
 
     const payload = {
       type: 'download_zero_start',
@@ -65,7 +78,7 @@ const DownloadZeroStartForm = ({ sitekey }: DownloadZeroStartFormProps) => {
       name,
       company,
       message,
-      source: 'download-zero-start',
+      source,
       phase: phaseValue,
       turnstileToken: turnstileToken ?? '',
     };
@@ -86,7 +99,7 @@ const DownloadZeroStartForm = ({ sitekey }: DownloadZeroStartFormProps) => {
       const eventParams: Record<string, string> = {
         form_id: 'download-zero-start',
         form_type: 'download_zero_start',
-        source: 'download-zero-start',
+        source,
         phase: phaseValue || 'unknown',
       };
 

--- a/src/lib/hearing/agent.ts
+++ b/src/lib/hearing/agent.ts
@@ -280,10 +280,7 @@ export async function runAgentTurn(
   profile: HearingProfile
 ): Promise<AgentTurnResult> {
   // ヒアリング専用モデルを優先 (JSON 出力厳守と instruction-following が必要)
-  const model =
-    env.OPENROUTER_MODEL_HEARING ??
-    env.OPENROUTER_MODEL_CHAT ??
-    'openai/gpt-4o-mini';
+  const model = env.OPENROUTER_MODEL_HEARING ?? env.OPENROUTER_MODEL_CHAT ?? 'openai/gpt-4o-mini';
   const messages = buildMessagesForLLM(history, profile);
 
   // 1回目

--- a/src/pages/case-studies.astro
+++ b/src/pages/case-studies.astro
@@ -472,9 +472,9 @@ const hasPrevPage = currentPage > 1;
       <div class="mt-24 text-center pb-16">
         <h2 class="text-3xl font-bold text-gray-900">お客様の事業成長をサポートします</h2>
         <p class="mt-4 text-xl text-gray-600">
-          まずは無料相談からお気軽にお問い合わせください
+          無料相談、または「初期費用0円で動くプロトタイプから判断する」仕組みをまとめた資料からどうぞ
         </p>
-        <div class="mt-8">
+        <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
           <a
             href="/contact?source=case-studies-final"
             data-cta-source="case-studies-final"
@@ -486,7 +486,19 @@ const hasPrevPage = currentPage > 1;
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
             </svg>
           </a>
+          <a
+            href="/downloads/zero-start?ref=case-studies"
+            data-cta-source="case-studies-final"
+            data-cta-id="download-zero-start"
+            class="inline-flex items-center justify-center px-8 py-4 text-lg font-medium text-primary-600 bg-white border-2 border-primary-500 rounded-full hover:bg-primary-50"
+          >
+            サービス資料をダウンロード
+            <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+          </a>
         </div>
+        <p class="mt-4 text-sm text-gray-500">PDF・約20ページ・無料／メールアドレスのみで受け取れます</p>
       </div>
     </section>
   </main>

--- a/src/pages/services/[id].astro
+++ b/src/pages/services/[id].astro
@@ -201,6 +201,17 @@ const faqNumber =
             </svg>
           </a>
           <a
+            href={`/downloads/zero-start?ref=services-${service.id}`}
+            data-cta-source={`services-${service.id}-final`}
+            data-cta-id="download-zero-start"
+            class="inline-flex items-center justify-center px-10 py-5 text-xl font-semibold text-accent-950 bg-highlight-300 rounded-full hover:bg-highlight-200 transition-all shadow-xl hover:shadow-2xl hover:scale-105 transform"
+          >
+            サービス資料をダウンロード
+            <svg class="w-6 h-6 ml-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+          </a>
+          <a
             href="/company"
             class="inline-flex items-center justify-center px-10 py-5 text-xl font-semibold text-white bg-transparent border-2 border-white rounded-full hover:bg-white hover:text-primary-500 transition-all"
           >


### PR DESCRIPTION
## 背景

GA4でAI検索(ChatGPT/Gemini/OpenAI)経由の実流入を確認(2026-05-30)。着地ページに `/case-studies`(事例集)と `/services/ai-development`(サービスLP)という検討段階の商用ページが含まれていた。ここに着地する層は温度が高い見込みのため、両ページの最終CTAに資料DL導線を追加し、流入元を計測できるようにする。

CRO方針(`.claude/rules/cro-strategy.md`)に沿い、サービス資料は既存のゲート付きLP `/downloads/zero-start`(メアド取得)へ誘導する。新規アセットは作らず既存ゲートLPを受け皿に使う。

## 変更内容

- **`/case-studies` 最終CTA**: 「無料相談」に並べて「サービス資料をダウンロード」を追加(`?ref=case-studies`)
- **`/services/[id]` 最終CTA**: 全サービスLPの最終CTAに「サービス資料をダウンロード」を追加(`?ref=services-<id>`、highlight色で配置)
- **`download-zero-start-form.tsx`**: URLの `?ref=` を取り込み、Slackリード通知の経由元(`source`)とGA4 `source` パラメータに流入元を反映。`type` とサーバー側の基底 `source` 値は維持し `/api/contact` は無改修で互換

## 計測導線

AI検索 → 事例集/サービスLP着地 → 資料DL → リード が、Slack通知(経由元行)とGA4(source)の両方で経由元付きで追える。

## 検証

- Biome: 編集3ファイルともクリーン(`bunx biome check` で確認)
- `bun run build`: 成功(SSRページ含めコンパイル通過)
- 未検証: 実機でのモバイル表示確認(servicesは3ボタンになるが `flex-col sm:flex-row` で縦積みになる作り)

## 注記

現状AI流入は各1セッション規模。効果測定はもう少し母数が貯まってから。

🤖 Generated with [Claude Code](https://claude.com/claude-code)