### PR TITLE
feat: AIデモをAI検索対策 — RAGナレッジ相談へリネーム + 構造化データ/FAQ

### DIFF
--- a/src/pages/demos/index.astro
+++ b/src/pages/demos/index.astro
@@ -1,8 +1,11 @@
 ---
 import { Header } from '../../components/header';
+import JsonLd from '../../components/seo/json-ld.astro';
 import FloatingCTA from '../../components/ui/floating-cta.astro';
 import { PageHero } from '../../components/ui/page-hero';
 import Layout from '../../layouts/layout.astro';
+
+const siteUrl = 'https://beekle.jp';
 
 const demos = [
   {
@@ -14,10 +17,10 @@ const demos = [
   },
   {
     href: '/demos/it-advisor',
-    label: 'AI質問bot',
+    label: 'AIナレッジ相談（RAG）',
     summary:
-      'システム発注・要件定義・見積もりの妥当性などの悩みをBeekleの相談員AIが一次回答します。',
-    badge: 'チャット',
+      'Beekleのコラム記事をベクトル検索（RAG）で参照する相談員AI。IT発注・要件定義・見積もりの悩みに一次回答します。御社の社内文書でも同じ仕組み（RAGシステム）を構築できます。',
+    badge: 'チャット (RAG)',
   },
   {
     href: '/demos/ocr',
@@ -27,11 +30,52 @@ const demos = [
     badge: 'ビジョン',
   },
 ];
+
+// AI検索（ChatGPT検索・Perplexity 等）に「Beekleが無料公開しているAIデモ」を
+// 引用させやすくするための FAQ。本文にも同じQ&Aを表示する（schemaと本文の一致）。
+const faqs = [
+  {
+    question: 'Beekleの生成AIデモは無料で使えますか？',
+    answer:
+      'はい。登録不要・無料でブラウザから試せます。現在「話すだけ発注準備」「AIナレッジ相談（RAG）」「AI領収書OCR」の3種類を公開しています。',
+  },
+  {
+    question: 'デモと本番サービスの違いは何ですか？',
+    answer:
+      'コスト節約のため、デモは軽量なモデル・構成です。本番ではより高精度・高速な構成で提供します。デモは「Beekleがこの種のAIを構築できる」ことを体感するためのものです。',
+  },
+  {
+    question: 'これらのデモはどんな技術で作られていますか？',
+    answer:
+      'AIナレッジ相談はコラム記事をベクトル検索するRAG、AI領収書OCRは画像からの構造化データ抽出、話すだけ発注準備は対話型AIと音声認識（Whisper）で構成しています。',
+  },
+  {
+    question: '自社の業務やデータで同じものを作れますか？',
+    answer:
+      'はい。RAG（社内文書AI検索）・OCR・AIエージェントいずれもBeekleの受託開発で構築できます。お問い合わせから具体的なご相談に進めます。',
+  },
+];
+
+const demoItemList = {
+  name: 'Beekleの生成AIデモ一覧',
+  url: `${siteUrl}/demos`,
+  itemType: 'SoftwareApplication',
+  items: demos.map((d) => ({
+    name: d.label,
+    description: d.summary,
+    url: d.href.startsWith('http') ? d.href : `${siteUrl}${d.href}`,
+  })),
+};
+
+const breadcrumbItems = [
+  { name: 'ホーム', url: '/' },
+  { name: 'AIデモ', url: '/demos' },
+];
 ---
 
 <Layout
   title="AIデモ｜Beekleが提供する生成AIの体験ページ | Beekle"
-  description="Beekleの生成AI技術を体験できるデモページ。話すだけ発注準備、AI質問bot、領収書OCRなど、業務効率化の感触を試せます。"
+  description="Beekleの生成AI技術を体験できるデモページ。話すだけ発注準備、AIナレッジ相談（RAG）、領収書OCRなど、業務効率化の感触を試せます。"
 >
   <Header client:load />
   <main class="pt-20">
@@ -69,6 +113,18 @@ const demos = [
           ))}
         </div>
 
+        <div class="mt-12">
+          <h2 class="text-lg font-bold text-navy-950 mb-4">よくある質問</h2>
+          <div class="space-y-3">
+            {faqs.map((f) => (
+              <div class="p-5 bg-white rounded-2xl border border-gray-200">
+                <p class="font-bold text-navy-950 mb-1.5">{f.question}</p>
+                <p class="text-sm text-gray-600 leading-relaxed">{f.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
         <div class="mt-12 p-6 bg-amber-50 border border-amber-200 rounded-2xl text-sm text-amber-900">
           <p class="font-bold mb-1">注意事項</p>
           <ul class="list-disc list-inside space-y-1">
@@ -83,3 +139,7 @@ const demos = [
     <FloatingCTA source="demos-index" />
   </main>
 </Layout>
+
+<JsonLd type="breadcrumb" data={{ items: breadcrumbItems }} />
+<JsonLd type="itemList" data={demoItemList} />
+<JsonLd type="faq" data={{ faqs }} />

--- a/src/pages/demos/it-advisor.astro
+++ b/src/pages/demos/it-advisor.astro
@@ -1,6 +1,7 @@
 ---
 import { AiItAdvisor } from '@/features/ai-it-advisor';
 import { Header } from '../../components/header';
+import JsonLd from '../../components/seo/json-ld.astro';
 import FloatingCTA from '../../components/ui/floating-cta.astro';
 import { PageHero } from '../../components/ui/page-hero';
 import Layout from '../../layouts/layout.astro';
@@ -10,13 +11,13 @@ const sitekey = runtime?.env?.TURNSTILE_SITE_KEY ?? '0x4AAAAAADHmRrTyQk-jx5-X';
 ---
 
 <Layout
-  title="AI質問bot (デモ)｜Beekleの相談員AIに気軽に質問 | Beekle"
-  description="システム発注・要件定義・見積もり妥当性など、IT発注のお悩みをBeekleのAI相談員が一次回答。専門用語を避けて短く具体的にお答えします。本格的な発注支援は人間のコンサルタントへ。"
+  title="AIナレッジ相談（RAG・デモ）｜Beekleの相談員AIに気軽に質問 | Beekle"
+  description="Beekleのコラム記事をベクトル検索（RAG）で参照し、システム発注・要件定義・見積もり妥当性などのお悩みにAI相談員が一次回答。御社の社内文書でも同じRAGの仕組みを構築できます。本格的な発注支援は人間のコンサルタントへ。"
 >
   <Header client:load />
   <main class="pt-20">
     <PageHero
-      title="AI質問bot (デモ)"
+      title="AIナレッジ相談（RAG・デモ）"
       subtitle="Beekleが公開しているコラムのノウハウをデータソースにして、AIが一次回答します。コラムが増えるほど回答精度も上がっていきます。"
       badge="AI Demo"
     />
@@ -57,3 +58,24 @@ const sitekey = runtime?.env?.TURNSTILE_SITE_KEY ?? '0x4AAAAAADHmRrTyQk-jx5-X';
     async
     defer></script>
 </Layout>
+
+<JsonLd
+  type="softwareApplication"
+  data={{
+    appName: 'AIナレッジ相談（RAG）',
+    appDescription:
+      'Beekleのコラム記事をベクトル検索（RAG）で参照し、IT発注・要件定義・見積もり妥当性などの悩みに一次回答する相談員AI。社内文書RAG構築の体験デモ。',
+    url: 'https://beekle.jp/demos/it-advisor',
+    applicationCategory: 'BusinessApplication',
+  }}
+/>
+<JsonLd
+  type="breadcrumb"
+  data={{
+    items: [
+      { name: 'ホーム', url: '/' },
+      { name: 'AIデモ', url: '/demos' },
+      { name: 'AIナレッジ相談（RAG）', url: '/demos/it-advisor' },
+    ],
+  }}
+/>

--- a/src/pages/demos/ocr.astro
+++ b/src/pages/demos/ocr.astro
@@ -1,6 +1,7 @@
 ---
 import { AiOcrDemo } from '@/features/ai-ocr-demo';
 import { Header } from '../../components/header';
+import JsonLd from '../../components/seo/json-ld.astro';
 import FloatingCTA from '../../components/ui/floating-cta.astro';
 import { PageHero } from '../../components/ui/page-hero';
 import Layout from '../../layouts/layout.astro';
@@ -50,3 +51,24 @@ const sitekey = runtime?.env?.TURNSTILE_SITE_KEY ?? '0x4AAAAAADHmRrTyQk-jx5-X';
     async
     defer></script>
 </Layout>
+
+<JsonLd
+  type="softwareApplication"
+  data={{
+    appName: 'AI領収書OCR',
+    appDescription:
+      '領収書の画像から店舗名・日付・合計・明細をAIが構造化データとして自動抽出する体験デモ。経費精算・帳票処理の自動化（OCR + LLM構造化）を試せます。',
+    url: 'https://beekle.jp/demos/ocr',
+    applicationCategory: 'FinanceApplication',
+  }}
+/>
+<JsonLd
+  type="breadcrumb"
+  data={{
+    items: [
+      { name: 'ホーム', url: '/' },
+      { name: 'AIデモ', url: '/demos' },
+      { name: 'AI領収書OCR', url: '/demos/ocr' },
+    ],
+  }}
+/>

--- a/src/pages/services/[id].astro
+++ b/src/pages/services/[id].astro
@@ -109,7 +109,7 @@ const faqNumber =
                 チャット (RAG)
               </span>
               <h3 class="text-xl font-bold mb-2 group-hover:text-primary-600 transition">
-                AI質問bot
+                AIナレッジ相談（RAG）
               </h3>
               <p class="text-sm text-gray-600 leading-relaxed">
                 Beekleのコラム記事を Embedding 検索でRAG参照する相談員AI。社内文書RAG構築の感触を体感できます。


### PR DESCRIPTION
## 概要

「AI質問bot」を「**AIナレッジ相談（RAG）**」にリネームし、AIデモページ群に AI検索（ChatGPT検索 / Perplexity 等）からの引用を狙った構造化データと FAQ を追加。

## 変更点

### リネーム + 説明強化
- 「AI質問bot」→「**AIナレッジ相談（RAG）**」（デモ一覧 / `/demos/it-advisor` / サービスページのデモカード）
- 説明に「コラム記事をベクトル検索（RAG）で参照」「御社の社内文書でも同じ仕組み（RAGシステム）を構築できます」を明記 → サービス（RAGシステム構築 / 社内文書AI検索）に接続

### AI検索対策（構造化データ）
- `/demos`: `ItemList`(SoftwareApplication) + `BreadcrumbList` + `FAQPage`
- 本文にも同じ FAQ を表示（schema と本文の一致 / 人にも有益）。Q: 無料か / 本番との違い / 使用技術(RAG・OCR・Whisper) / 自社展開可否
- `/demos/it-advisor`・`/demos/ocr`: 各 `SoftwareApplication`(isAccessibleForFree, price 0) + `BreadcrumbList`

いずれも既存の共有コンポーネント `src/components/seo/json-ld.astro` を利用（新規スキーマ追加なし）。

## 検証
- `bun run build` pass / Biome clean
- JSON-LD の実出力は preview デプロイで確認予定（dev サーバは .astro frontmatter のHMR未反映で旧状態を返すため）