### PR TITLE
fix(security): Slack mrkdwn インジェクション対策（/api/contact）

### DIFF
--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -139,10 +139,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
     }
 
     const typeStr = type;
+    // ユーザー由来の値は Slack mrkdwn の制御文字 (& < >) を無害化してから埋め込む。
+    // これで <!channel>/<!here> の全員メンション、<url|偽装テキスト> のフィッシングリンク注入を防ぐ。
     const provenanceParts = [
-      source ? `source: ${source}` : '',
-      intent ? `intent: ${intent}` : '',
-      phase ? `phase: ${phase}` : '',
+      source ? `source: ${escapeSlack(source)}` : '',
+      intent ? `intent: ${escapeSlack(intent)}` : '',
+      phase ? `phase: ${escapeSlack(phase)}` : '',
     ].filter(Boolean);
     const provenanceText =
       provenanceParts.length > 0 ? provenanceParts.join(' / ') : '直接アクセス';
@@ -156,16 +158,19 @@ export const POST: APIRoute = async ({ request, locals }) => {
         {
           type: 'section',
           fields: [
-            { type: 'mrkdwn', text: `*種別:*\n${TYPE_LABELS[typeStr] || typeStr || '未選択'}` },
-            { type: 'mrkdwn', text: `*メール:*\n${email}` },
-            { type: 'mrkdwn', text: `*お名前:*\n${name || '未記入'}` },
-            { type: 'mrkdwn', text: `*会社名:*\n${company || '未記入'}` },
-            { type: 'mrkdwn', text: `*電話番号:*\n${phone || '未記入'}` },
+            {
+              type: 'mrkdwn',
+              text: `*種別:*\n${TYPE_LABELS[typeStr] || escapeSlack(typeStr) || '未選択'}`,
+            },
+            { type: 'mrkdwn', text: `*メール:*\n${escapeSlack(email)}` },
+            { type: 'mrkdwn', text: `*お名前:*\n${escapeSlack(name) || '未記入'}` },
+            { type: 'mrkdwn', text: `*会社名:*\n${escapeSlack(company) || '未記入'}` },
+            { type: 'mrkdwn', text: `*電話番号:*\n${escapeSlack(phone) || '未記入'}` },
           ],
         },
         {
           type: 'section',
-          text: { type: 'mrkdwn', text: `*お問い合わせ内容:*\n${message}` },
+          text: { type: 'mrkdwn', text: `*お問い合わせ内容:*\n${escapeSlack(message)}` },
         },
         {
           type: 'context',
@@ -193,4 +198,10 @@ function jsonError(status: number, error: string, details: string) {
     status,
     headers: { 'Content-Type': 'application/json' },
   });
+}
+
+// Slack mrkdwn のエスケープ（公式仕様: & < > のみ）。
+// <!channel> / <!here> の全員メンションや <https://evil|テキスト> のリンク偽装を無害化する。
+function escapeSlack(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }


### PR DESCRIPTION
## 概要

AIデモのセキュリティ点検で発見した実在の脆弱性を修正。

`/api/contact` がユーザー由来の `message` / `name` / `company` / `email` / `phone` / `source` 等を **エスケープせず Slack mrkdwn に埋め込んでいた**ため、以下が可能だった:

- `<!channel>` / `<!here>` → 社内 Slack の**全員メンション**（通知スパム）
- `<https://evil.example|至急ご確認ください>` → 社員向け**フィッシングリンク**を社内チャンネルに注入

「話すだけ発注準備」(flow-interview) の AI 生成内容（As-Is/To-Be/RFP）経由でも、会話でAIを誘導して同様の文字列を混入させられる流入経路がある。

## 修正

- `escapeSlack()`（Slack公式仕様の `&` `<` `>` エスケープ）を追加
- Slack 通知に埋め込む全ユーザー由来値に適用

## 影響範囲外（点検で問題なしと確認した点）
- 濫用/コスト: `aiGuards`（Turnstile + IPレート制限 + 月次予算 kill-switch）で対策済み
- chat 出力の URL 捏造: `sanitizeReplyUrls`（beekle.jp + 参考コラムURL の allowlist）で物理的に遮断済み
- LLM にツール/関数を渡していない → データ持ち出し経路なし。RAGソースは自社コラム（信頼済み）
- 入力検証: chat 800字 / OCR MIME+5MB / transcribe セッション必須+8MB

## 検証
- `bun run build` pass / Biome clean