### PR TITLE
feat: 問い合わせフォームに流入アトリビューションを付与（参照元/着地/UTM/GA cid）

### DIFF
--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -1,3 +1,4 @@
+import { getAttribution } from '@/lib/attribution';
 import { consumeContactPrefill } from '@/lib/contact-prefill';
 import { useTurnstile } from '@/lib/use-turnstile';
 import type React from 'react';
@@ -83,6 +84,8 @@ const ContactForm = ({ sitekey }: ContactFormProps) => {
       intent: provenance.intent,
       phase: provenance.phase,
       turnstileToken: turnstileToken ?? '',
+      // 流入元（入口ページ・参照元・UTM・GA client_id）を問い合わせ通知へ同送
+      ...getAttribution(),
     };
 
     try {

--- a/src/components/download-zero-start-form.tsx
+++ b/src/components/download-zero-start-form.tsx
@@ -1,3 +1,4 @@
+import { getAttribution } from '@/lib/attribution';
 import { useTurnstile } from '@/lib/use-turnstile';
 import type React from 'react';
 import { useState } from 'react';
@@ -81,6 +82,8 @@ const DownloadZeroStartForm = ({ sitekey }: DownloadZeroStartFormProps) => {
       source,
       phase: phaseValue,
       turnstileToken: turnstileToken ?? '',
+      // 流入元（入口ページ・参照元・UTM・GA client_id）を問い合わせ通知へ同送
+      ...getAttribution(),
     };
 
     try {

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -45,6 +45,9 @@ const fullTitle = title.includes('Beekle') ? title : `${title} | Beekle`;
     <slot />
     <script>
       import { initEngagementTracking, trackCtaClick } from '@/lib/analytics';
+      import { captureFirstTouch } from '@/lib/attribution';
+      // セッション最初のページで入口・参照元・UTM を記録（フォーム送信時に問い合わせ通知へ載せる）
+      captureFirstTouch();
       document.addEventListener('click', (event) => {
         const target = event.target;
         if (!(target instanceof Element)) return;

--- a/src/lib/attribution.ts
+++ b/src/lib/attribution.ts
@@ -1,0 +1,83 @@
+// フォーム送信時に「どこから来たか」を捕捉するための first-touch アトリビューション。
+// contact API はペイロードに無い情報を保存できないため、入口ページ・参照元・UTM・GA client_id を
+// クライアントで集めて /api/contact に同送し、Slack 通知に載せる。
+// user_id を持たない設計（.claude/rules/analytics-ga4.md）のため、GA client_id が
+// GA4 探索との後追い照合の唯一の手がかりになる。
+
+const FIRST_TOUCH_KEY = 'beekle-first-touch-v1';
+
+type FirstTouch = {
+  landingPage: string;
+  referrer: string;
+  utmSource: string;
+  utmMedium: string;
+  utmCampaign: string;
+  ts: number;
+};
+
+export type Attribution = {
+  clientId: string;
+  landingPage: string;
+  referrer: string;
+  utmSource: string;
+  utmMedium: string;
+  utmCampaign: string;
+};
+
+// セッション最初のページで入口情報を記録する（冪等。layout から全ページで呼ぶ）。
+// 既に記録済みなら何もしないので、回遊後にフォーム到達しても「最初に踏んだ外部参照元」が残る。
+export function captureFirstTouch(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (window.sessionStorage.getItem(FIRST_TOUCH_KEY)) return;
+    const sp = new URLSearchParams(window.location.search);
+    const data: FirstTouch = {
+      landingPage: window.location.pathname + window.location.search,
+      // 同一オリジンからの遷移後に記録しても、初回呼び出し時点の referrer は外部参照元になる
+      referrer: document.referrer || '',
+      utmSource: sp.get('utm_source') || '',
+      utmMedium: sp.get('utm_medium') || '',
+      utmCampaign: sp.get('utm_campaign') || '',
+      ts: Date.now(),
+    };
+    window.sessionStorage.setItem(FIRST_TOUCH_KEY, JSON.stringify(data));
+  } catch {
+    // プライベートモード等で sessionStorage が使えない場合は黙って諦める（計測は best-effort）
+  }
+}
+
+function readFirstTouch(): Partial<FirstTouch> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.sessionStorage.getItem(FIRST_TOUCH_KEY);
+    return raw ? (JSON.parse(raw) as Partial<FirstTouch>) : {};
+  } catch {
+    return {};
+  }
+}
+
+// `_ga` クッキー（GA1.1.<part1>.<part2>）から GA4 client_id（<part1>.<part2>）を取り出す。
+export function getGaClientId(): string {
+  if (typeof document === 'undefined') return '';
+  const match = document.cookie.match(/(?:^|;\s*)_ga=([^;]+)/);
+  if (!match) return '';
+  const parts = match[1].split('.');
+  if (parts.length >= 4) return `${parts[parts.length - 2]}.${parts[parts.length - 1]}`;
+  return '';
+}
+
+const cap = (value: string, max: number): string =>
+  value.length > max ? value.slice(0, max) : value;
+
+// フォーム送信ペイロードに添えるアトリビューション一式を返す。
+export function getAttribution(): Attribution {
+  const ft = readFirstTouch();
+  return {
+    clientId: getGaClientId(),
+    landingPage: cap(ft.landingPage || '', 300),
+    referrer: cap(ft.referrer || '', 300),
+    utmSource: cap(ft.utmSource || '', 80),
+    utmMedium: cap(ft.utmMedium || '', 80),
+    utmCampaign: cap(ft.utmCampaign || '', 120),
+  };
+}

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -33,6 +33,13 @@ const ContactSchema = z.object({
   turnstileToken: z.string().optional().default(''),
   // flow-interview など、開始時に既に Turnstile を通したセッション経由の送信
   sessionId: z.string().optional().default(''),
+  // 流入アトリビューション（src/lib/attribution.ts が付与）。クライアント由来なので長さ制限のみ。
+  clientId: z.string().trim().max(120).optional().default(''),
+  landingPage: z.string().trim().max(400).optional().default(''),
+  referrer: z.string().trim().max(400).optional().default(''),
+  utmSource: z.string().trim().max(120).optional().default(''),
+  utmMedium: z.string().trim().max(120).optional().default(''),
+  utmCampaign: z.string().trim().max(160).optional().default(''),
 });
 
 const SLACK_TIMEOUT_MS = 8000;
@@ -109,6 +116,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
       phase,
       turnstileToken,
       sessionId,
+      clientId,
+      landingPage,
+      referrer,
+      utmSource,
+      utmMedium,
+      utmCampaign,
     } = parsed.data;
 
     // 既存の AI セッション（開始時に Turnstile 検証済み）からの送信は再検証を免除する。
@@ -148,6 +161,18 @@ export const POST: APIRoute = async ({ request, locals }) => {
     ].filter(Boolean);
     const provenanceText =
       provenanceParts.length > 0 ? provenanceParts.join(' / ') : '直接アクセス';
+
+    // 流入アトリビューション（入口ページ・外部参照元・UTM・GA client_id）。
+    // 参照元が空＝直接/ブックマーク/外部アプリ。client_id は GA4 探索での後追い照合用。
+    const utmText = [utmSource, utmMedium, utmCampaign].filter(Boolean).join(' / ');
+    const attributionLine = [
+      `着地: ${landingPage ? escapeSlack(landingPage) : '不明'}`,
+      `参照元: ${referrer ? escapeSlack(referrer) : '直接/なし'}`,
+      utmText ? `UTM: ${escapeSlack(utmText)}` : '',
+      clientId ? `GA cid: ${escapeSlack(clientId)}` : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
     const slackMessage = {
       text: '新しいお問い合わせが届きました',
       blocks: [
@@ -175,6 +200,10 @@ export const POST: APIRoute = async ({ request, locals }) => {
         {
           type: 'context',
           elements: [{ type: 'mrkdwn', text: `*経由元:* ${provenanceText}` }],
+        },
+        {
+          type: 'context',
+          elements: [{ type: 'mrkdwn', text: `*流入:*\n${attributionLine}` }],
         },
         { type: 'divider' },
       ],


### PR DESCRIPTION
## 背景

問い合わせ通知から「どう来たか（流入元）」が分からなかった。`/api/contact` の `source`（例: `header-desktop`）は**サイト内のどのCTAを押したか**を示すだけで、外部参照元・検索・UTM・チャネルを一切保存していなかった。

実例: 2026-06-12 の問い合わせ（株式会社シフト）で `source: header-desktop` しか残らず、GA4 でも user_id 無し設計＋当日データ未処理のため経路を再構成できなかった。

## 変更

- `src/lib/attribution.ts`（新規）: `captureFirstTouch`（着地ページ・外部 referrer・UTM を sessionStorage に記録、冪等）/ `getGaClientId`（`_ga` クッキーから client_id 抽出）/ `getAttribution`
- `layout.astro`: 全ページで `captureFirstTouch()` を実行
- `contact-form.tsx` / `download-zero-start-form.tsx`: 送信ペイロードに `getAttribution()` を同送
- `contact.ts`: zod スキーマに `clientId/landingPage/referrer/utm*` を追加（長さ制限付き）+ Slack 通知に「流入」ブロック（着地 / 参照元 / UTM / GA cid）を追加。`escapeSlack` で既存どおり mrkdwn インジェクション対策済み

## 効果・制約

- 本変更**以降**の問い合わせは Slack 通知に流入元が出る。既存は遡及不可
- user_id を持たない設計のため、GA client_id が GA4 探索との後追い照合の手がかり
- 参照元が空＝直接/ブックマーク/外部アプリ

## 検証

- 変更5ファイル Biome クリーン（残エラーは無関係な untracked スクリプト）
- `bun run build` 成功
- GA client_id パーサを5ケースで確認（`_gid` 誤検出しないことを含め全パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)