### PR TITLE
feat: Microsoft Clarity（ヒートマップ/セッション録画）を導入

### DIFF
--- a/src/components/analytics/clarity.astro
+++ b/src/components/analytics/clarity.astro
@@ -1,0 +1,20 @@
+---
+// Microsoft Clarity（ヒートマップ + セッション録画）。
+// CVR改善のトラックA（動線改善）で「なぜ発注者が離脱するか」を実観察するために導入。
+// 本番ドメイン (beekle.jp / www.beekle.jp) でのみ起動し、dev・preview(*.pages.dev) の
+// 録画でダッシュボードを汚さない。Project ID は公開クライアントID（GA測定IDと同様にハードコード可）。
+const CLARITY_PROJECT_ID = 'x69z1qvv1l';
+---
+
+<script is:inline define:vars={{ CLARITY_PROJECT_ID }}>
+  if (/(^|\.)beekle\.jp$/.test(location.hostname)) {
+    (function (c, l, a, r, i, t, y) {
+      c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments); };
+      t = l.createElement(r);
+      t.async = 1;
+      t.src = 'https://www.clarity.ms/tag/' + i;
+      y = l.getElementsByTagName(r)[0];
+      y.parentNode.insertBefore(t, y);
+    })(window, document, 'clarity', 'script', CLARITY_PROJECT_ID);
+  }
+</script>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -1,5 +1,6 @@
 ---
 // src/layouts/layout.astro
+import Clarity from '../components/analytics/clarity.astro';
 import GA4 from '../components/analytics/ga4.astro';
 import JsonLd from '../components/seo/json-ld.astro';
 import SeoHead from '../components/seo/seo-head.astro';
@@ -39,6 +40,7 @@ const fullTitle = title.includes('Beekle') ? title : `${title} | Beekle`;
     />
     <JsonLd type="organization" />
     <GA4 />
+    <Clarity />
     <slot name="head" />
   </head>
   <body class="font-sans">


### PR DESCRIPTION
## 背景

CVR改善フェーズ（次の主目標）のトラックA＝動線改善で、「なぜ発注者が離脱するか」を録画とヒートマップで実観察するために Microsoft Clarity を導入する。

## 変更

- `src/components/analytics/clarity.astro`（新規）: Clarity タグ（project `x69z1qvv1l`）
- `layout.astro`: GA4 の直後に `<Clarity />` を head で読み込み（全ページ）

## 安全策

- **本番ドメイン (`beekle.jp` / `www.beekle.jp`) でのみ起動**するホスト名ガード。dev・preview(`*.pages.dev`) のセッション録画で Clarity ダッシュボードを汚さない
- Project ID は公開クライアントID（GA測定IDと同方針でハードコード、env 不要）
- 依存追加なし（lockfile 同期不要）

## 検証

- 変更ファイル Biome クリーン / `bun run build` 成功
- ビルド出力（layout チャンク）にホスト名ガード付きスニペットが正しく描画されることを確認

## フォローアップ（このPRには含めない）

- プライバシーポリシー(`/privacy`)に Clarity（セッション録画/ヒートマップ）の記載を追記。Clarity は既定で全テキスト/入力をマスクするが、計測ツール明示のため

🤖 Generated with [Claude Code](https://claude.com/claude-code)