### PR TITLE
docs(privacy): プライバシーポリシーに Microsoft Clarity を開示

### DIFF
--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -96,6 +96,7 @@ const established = '2024年1月1日';
                   <tr><td class="border border-gray-200 px-4 py-2">OpenRouter, Inc.</td><td class="border border-gray-200 px-4 py-2">米国</td><td class="border border-gray-200 px-4 py-2">AIデモにおける生成AIモデル（Google Gemini 等）への中継およびAPI提供</td></tr>
                   <tr><td class="border border-gray-200 px-4 py-2">株式会社microCMS</td><td class="border border-gray-200 px-4 py-2">日本</td><td class="border border-gray-200 px-4 py-2">公開コンテンツ（コラム等）の管理</td></tr>
                   <tr><td class="border border-gray-200 px-4 py-2">Google LLC</td><td class="border border-gray-200 px-4 py-2">米国</td><td class="border border-gray-200 px-4 py-2">アクセス解析（Google Analytics 4）、サーチコンソール</td></tr>
+                  <tr><td class="border border-gray-200 px-4 py-2">Microsoft Corporation</td><td class="border border-gray-200 px-4 py-2">米国</td><td class="border border-gray-200 px-4 py-2">アクセス解析（Microsoft Clarity｜ヒートマップ・セッション録画）</td></tr>
                   <tr><td class="border border-gray-200 px-4 py-2">Slack Technologies, LLC</td><td class="border border-gray-200 px-4 py-2">米国</td><td class="border border-gray-200 px-4 py-2">お問い合わせ通知の社内受信</td></tr>
                 </tbody>
               </table>
@@ -121,6 +122,9 @@ const established = '2024年1月1日';
             <h2 class="text-2xl font-bold text-gray-800 mt-12 mb-6">8. Cookie・アクセス解析</h2>
             <p class="text-gray-600 mb-4">
               本サイトでは、利用状況の分析および機能提供のために Cookie および類似技術を使用しています。Google Analytics 4（GA4）により、Cookieに付与された識別子・IPアドレス（短縮処理）等を用いて統計情報を取得します。GA4による情報収集を拒否する場合、ブラウザの Cookie 設定変更、または Google が提供するオプトアウトアドオン（<a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer" class="text-primary-600 underline">https://tools.google.com/dlpage/gaoptout</a>）をご利用ください。
+            </p>
+            <p class="text-gray-600 mb-8">
+              また、サイトの使いやすさ改善のために Microsoft Clarity（Microsoft Corporation 提供）を利用し、ページ内のクリック・スクロール・マウス操作などの行動を統計的に分析します（ヒートマップおよびセッション録画）。入力欄の文字や個人を特定しうるテキストは既定でマスクされ、当社・Microsoft いずれにおいても記録されません。情報収集を拒否する場合は、ブラウザの Cookie 設定変更、または Do Not Track（トラッキング拒否）設定をご利用ください。詳細は Microsoft の<a href="https://privacy.microsoft.com/privacystatement" target="_blank" rel="noopener noreferrer" class="text-primary-600 underline">プライバシーステートメント</a>をご参照ください。
             </p>
             <p class="text-gray-600 mb-8">
               本サイトの一部機能（AIデモのチャット履歴等）は、ブラウザのローカルストレージにデータを保存します。これらはお客様の端末内で完結し、当社サーバーには送信されません。


### PR DESCRIPTION
## 背景
Microsoft Clarity 導入（PR #48）の法的フォローアップ。プライバシーポリシーに計測ツールを明示する。

## 変更
- 委託先テーブルに `Microsoft Corporation`（米国／セッション録画・ヒートマップ）を追加
- 8章「Cookie・アクセス解析」に Clarity の説明、入力文字の既定マスク、オプトアウト方法（Cookie設定 / Do Not Track）、Microsoft プライバシーステートメントへのリンクを追記

## 検証
- Biome クリーン / `bun run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)