### PR TITLE
feat(contact): お問い合わせ種別に「開発パートナー・協業」を追加

### DIFF
--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -164,6 +164,7 @@ const ContactForm = ({ sitekey }: ContactFormProps) => {
             <option value="prototype">プロトタイプ・POC作成について</option>
             <option value="ai">AI/AIエージェント開発について</option>
             <option value="global">海外向けサービス開発について</option>
+            <option value="partner">開発パートナー・協業のご相談（開発会社・SIer様）</option>
             <option value="other">その他</option>
           </select>
         </div>

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -12,6 +12,7 @@ const TYPE_LABELS: Record<string, string> = {
   prototype: 'プロトタイプ・POC作成について',
   ai: 'AI/AIエージェント開発について',
   global: '海外向けサービス開発について',
+  partner: '開発パートナー・協業のご相談（開発会社・SIer様）',
   other: 'その他',
   download_zero_start: '【資料DL】ゼロスタート開発サービスデック',
 };


### PR DESCRIPTION
## 背景
お問い合わせの3セグメントのうち B（下請け/協業探しの同業＝Web制作会社・SIer・コンサルのテック側）を取りこぼさないための第一歩。田中さん（シフト, 2026-06-12）がこの型で、marketing.md の実績の多くも元請けの下請け・協業＝実証済み収益チャネル。

## 変更
- `contact-form.tsx`: 種別 select に `partner`（開発パートナー・協業のご相談）を追加
- `contact.ts`: `TYPE_LABELS` に `partner` を追加（Slack 通知ラベル）

## 注意（フォローアップ）
種別追加は最小コストだが、これ単独では弱い。技術ページ（ai-development / cdp-development / RAG）に「開発パートナーをお探しの開発会社・SIer様へ」の協業 CTA / 導線を後続で入れて、B セグメントへの流入を作る必要がある。

## 検証
- Biome クリーン / `bun run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)