### PR TITLE
fix(column): 本文リンク直後の余白を解消

### DIFF
--- a/src/pages/column/[...slug].astro
+++ b/src/pages/column/[...slug].astro
@@ -593,16 +593,22 @@ const reviewerId = column.category?.id ? categoryReviewerMap[column.category.id]
     border-bottom-color: currentColor;
   }
 
+  /* ホバー時のみ → を出す。非ホバー時は幅・余白をゼロに畳み、
+     リンク直後の句読点との間に余白が残らないようにする（CJK本文での見た目崩れ防止）。 */
   .markdown-content :global(a)::after {
     content: '→';
-    margin-left: 0.25rem;
+    margin-left: 0;
+    max-width: 0;
+    overflow: hidden;
     opacity: 0;
     transition: all 0.2s ease;
     display: inline-block;
+    vertical-align: bottom;
   }
 
   .markdown-content :global(a):hover::after {
     opacity: 1;
+    max-width: 1.5em;
     margin-left: 0.375rem;
   }
 


### PR DESCRIPTION
## 症状
コラム本文中のインラインリンク（例: 「FM法の使い方」「スコープ管理ツール」）の直後に、句読点との間で不自然な余白が入る（モバイルで顕著、ユーザー報告）。

## 原因
`.markdown-content a::after` のホバー用「→」矢印が、`opacity: 0` で不可視でも `display: inline-block` + `content: '→'` + `margin-left: 0.25rem` により**横幅を占有**していた。CJK の流し込み本文でリンク直後に句読点が来ると、その占有幅が余白として見える。

## 修正
非ホバー時は `max-width: 0` + `overflow: hidden` + `margin-left: 0` で幅ゼロに畳み、ホバー時のみ `max-width: 1.5em` + `margin-left: 0.375rem` で展開。ホバー矢印UXは維持。

## 検証
- Playwright 実測（該当CSSを切り出し）: 非ホバー時のリンク〜後続テキストの余白 **0px**（afterの max-width/margin も 0）、ホバー時に矢印が展開（max-width 24px）
- 同 `content: '→'` パターンは他ファイルに無いことを確認（影響はこの1ファイルのみ）
- `bun run build` 成功 / Biome クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)