### PR TITLE
feat(cta): 買い手ページに意図別の相談CTAを追加

### DIFF
--- a/scripts/patch-buyer-consult-cta.mjs
+++ b/scripts/patch-buyer-consult-cta.mjs
@@ -1,0 +1,109 @@
+/**
+ * 買い手意図ページに意図別相談CTAマーカーを挿入する (2026-06-19)
+ *
+ * AI Citations 分析で「AIが見積・RFP・CDP比較の発注者を送り込んでいる」と判明した
+ * ページに、意図別の相談CTA（{{ESTIMATE_CONSULT}} 等、column-visuals.ts で定義）を入れる。
+ *
+ *   node --env-file=.env scripts/patch-buyer-consult-cta.mjs          # dry-run
+ *   node --env-file=.env scripts/patch-buyer-consult-cta.mjs --apply  # PATCH
+ */
+import { createClient } from 'microcms-js-sdk';
+
+const client = createClient({
+  serviceDomain: process.env.MICROCMS_SERVICE_DOMAIN,
+  apiKey: process.env.MICROCMS_API_KEY,
+});
+
+const DRY_RUN = !process.argv.includes('--apply');
+
+const PATCHES = [
+  { slug: 'system-development-cost-breakdown', action: 'append', marker: 'ESTIMATE_CONSULT' },
+  { slug: 'quote-comparison-checklist', action: 'append', marker: 'ESTIMATE_CONSULT' },
+  { slug: 'ai-development-cost-guide', action: 'replace', from: 'CONTACT_CTA', to: 'ESTIMATE_CONSULT' },
+  // 末尾のベタ書き汎用CTA（h3「Beekleにご相談ください」＋段落＋/contactリンク）を CDP特化に置換
+  {
+    slug: 'cdp-product-comparison',
+    action: 'replaceTail',
+    re: /<h3[^>]*>Beekleにご相談ください<\/h3>[\s\S]*$/,
+    to: 'CDP_CONSULT',
+  },
+  { slug: 'how-to-write-rfp', action: 'replace', from: 'CONTACT_CTA', to: 'RFP_CONSULT' },
+  { slug: 'requirements-definition-template', action: 'append', marker: 'REQ_CONSULT' },
+  { slug: 'requirements-vs-requests', action: 'append', marker: 'REQ_CONSULT' },
+];
+
+const has = (content, marker) => content.includes(`{{${marker}}}`);
+
+console.log(`モード: ${DRY_RUN ? 'DRY-RUN (書き込みなし)' : 'APPLY (MicroCMS PATCH)'}\n`);
+
+let changed = 0;
+const errors = [];
+
+for (const p of PATCHES) {
+  console.log(`--- ${p.slug} (${p.action}: ${p.marker || `${p.from}→${p.to}`}) ---`);
+  let cur;
+  try {
+    cur = await client.get({ endpoint: 'columns', contentId: p.slug, queries: { fields: 'content' } });
+  } catch (e) {
+    console.error(`  [NG] 取得失敗: ${e.message}`);
+    errors.push(`${p.slug}: ${e.message}`);
+    continue;
+  }
+  let content = cur.content || '';
+  let next = content;
+
+  if (p.action === 'append') {
+    if (has(content, p.marker)) {
+      console.log('  [skip] 既に挿入済み');
+      continue;
+    }
+    next = `${content.trimEnd()}\n<p>{{${p.marker}}}</p>\n`;
+  } else if (p.action === 'replaceTail') {
+    if (has(content, p.to)) {
+      console.log('  [skip] 既に置換済み');
+      continue;
+    }
+    if (!p.re.test(content)) {
+      console.error('  [NG] 置換対象の末尾ブロックが見つからない（手動確認が必要）');
+      errors.push(`${p.slug}: replaceTail target not found`);
+      continue;
+    }
+    next = `${content.replace(p.re, '').trimEnd()}\n<p>{{${p.to}}}</p>\n`;
+  } else if (p.action === 'replace') {
+    if (has(content, p.to)) {
+      console.log('  [skip] 既に置換済み');
+      continue;
+    }
+    if (!has(content, p.from)) {
+      console.log(`  [warn] 置換元 {{${p.from}}} が見つからないため末尾に追記`);
+      next = `${content.trimEnd()}\n<p>{{${p.to}}}</p>\n`;
+    } else {
+      // 末尾(final)の {{CONTACT_CTA}} のみ置換。MID 等は触らない（厳密一致）
+      next = content.replace(`<p>{{${p.from}}}</p>`, `<p>{{${p.to}}}</p>`);
+      if (next === content) next = content.replace(`{{${p.from}}}`, `{{${p.to}}}`);
+    }
+  }
+
+  if (next === content) {
+    console.log('  [skip] 変更なし');
+    continue;
+  }
+  console.log(`  挿入後 末尾120字: ...${next.slice(-120).replace(/\n/g, '⏎')}`);
+  changed++;
+
+  if (!DRY_RUN) {
+    try {
+      await client.update({ endpoint: 'columns', contentId: p.slug, content: { content: next } });
+      const ver = await client.get({ endpoint: 'columns', contentId: p.slug, queries: { fields: 'content' } });
+      const target = p.action === 'replace' ? p.to : p.marker;
+      console.log(`  [OK] PATCH完了 / 検証: {{${target}}} ${has(ver.content || '', target) ? '存在' : '★欠落'}`);
+    } catch (e) {
+      console.error(`  [NG] PATCH失敗: ${e.message}`);
+      errors.push(`${p.slug}: ${e.message}`);
+    }
+  }
+}
+
+console.log(`\n${DRY_RUN ? '変更予定' : '変更'}: ${changed}件 / エラー: ${errors.length}件`);
+if (errors.length) for (const e of errors) console.log(`  - ${e}`);
+if (DRY_RUN) console.log('\n--apply で実行');

--- a/scripts/patch-buyer-consult-cta.mjs
+++ b/scripts/patch-buyer-consult-cta.mjs
@@ -19,7 +19,12 @@ const DRY_RUN = !process.argv.includes('--apply');
 const PATCHES = [
   { slug: 'system-development-cost-breakdown', action: 'append', marker: 'ESTIMATE_CONSULT' },
   { slug: 'quote-comparison-checklist', action: 'append', marker: 'ESTIMATE_CONSULT' },
-  { slug: 'ai-development-cost-guide', action: 'replace', from: 'CONTACT_CTA', to: 'ESTIMATE_CONSULT' },
+  {
+    slug: 'ai-development-cost-guide',
+    action: 'replace',
+    from: 'CONTACT_CTA',
+    to: 'ESTIMATE_CONSULT',
+  },
   // 末尾のベタ書き汎用CTA（h3「Beekleにご相談ください」＋段落＋/contactリンク）を CDP特化に置換
   {
     slug: 'cdp-product-comparison',
@@ -43,13 +48,17 @@ for (const p of PATCHES) {
   console.log(`--- ${p.slug} (${p.action}: ${p.marker || `${p.from}→${p.to}`}) ---`);
   let cur;
   try {
-    cur = await client.get({ endpoint: 'columns', contentId: p.slug, queries: { fields: 'content' } });
+    cur = await client.get({
+      endpoint: 'columns',
+      contentId: p.slug,
+      queries: { fields: 'content' },
+    });
   } catch (e) {
     console.error(`  [NG] 取得失敗: ${e.message}`);
     errors.push(`${p.slug}: ${e.message}`);
     continue;
   }
-  let content = cur.content || '';
+  const content = cur.content || '';
   let next = content;
 
   if (p.action === 'append') {
@@ -94,9 +103,15 @@ for (const p of PATCHES) {
   if (!DRY_RUN) {
     try {
       await client.update({ endpoint: 'columns', contentId: p.slug, content: { content: next } });
-      const ver = await client.get({ endpoint: 'columns', contentId: p.slug, queries: { fields: 'content' } });
+      const ver = await client.get({
+        endpoint: 'columns',
+        contentId: p.slug,
+        queries: { fields: 'content' },
+      });
       const target = p.action === 'replace' ? p.to : p.marker;
-      console.log(`  [OK] PATCH完了 / 検証: {{${target}}} ${has(ver.content || '', target) ? '存在' : '★欠落'}`);
+      console.log(
+        `  [OK] PATCH完了 / 検証: {{${target}}} ${has(ver.content || '', target) ? '存在' : '★欠落'}`
+      );
     } catch (e) {
       console.error(`  [NG] PATCH失敗: ${e.message}`);
       errors.push(`${p.slug}: ${e.message}`);

--- a/src/lib/column-cta-mapping.ts
+++ b/src/lib/column-cta-mapping.ts
@@ -44,6 +44,31 @@ const PROOFFIRST: CtaItem = {
   ctaId: 'prooffirst',
 };
 
+// 買い手意図カテゴリ向けのリード獲得CTA（ツールでなく相談・資料DLを主動線にする）
+const ESTIMATE_CONSULT: CtaItem = {
+  href: '/contact?intent=estimate',
+  label: '開発費用を相談する（無料）',
+  description:
+    '要件と規模感をお伝えいただければ、概算の費用レンジと内訳の考え方を無料でご返信します',
+  ctaId: 'consult-estimate',
+};
+
+const CDP_CONSULT: CtaItem = {
+  href: '/contact?intent=cdp',
+  label: 'CDP導入・選定を相談する',
+  description:
+    'Treasure Data・Salesforce CDP・BigQuery自社開発など、自社に合うCDPの選び方を無料でご相談いただけます',
+  ctaId: 'consult-cdp',
+};
+
+const DOWNLOAD_DECK: CtaItem = {
+  href: '/downloads/zero-start',
+  label: 'サービス資料を無料ダウンロード',
+  description:
+    'ゼロスタート開発（初期費用0円で動くプロトタイプ）のサービス資料を無料配布しています',
+  ctaId: 'download-zero-start',
+};
+
 function buildCta(primary: CtaItem, secondary?: CtaItem): CategoryCta {
   return {
     primary,
@@ -57,21 +82,22 @@ function buildCta(primary: CtaItem, secondary?: CtaItem): CategoryCta {
 
 const DEFAULT_CTA: CategoryCta = buildCta(PROOFFIRST);
 
+// キーは MicroCMS の実カテゴリ ID と一致させること。
+// 買い手意図が強いカテゴリ（estimate-concerns / cdp-development）は、AI検索が見積もり・
+// 費用・CDP比較の発注者を送り込む受け皿。主CTAをツールでなく相談・資料DL（リード獲得）にする。
 const MAPPING: Record<string, CategoryCta> = {
-  // プロジェクト管理: 業務洗い出し → スコープ整理の流れ
+  // プロジェクト管理: 業務洗い出し → スコープ整理（実務記事も混在するためツール主体のまま。
+  // 買い手ページは本文内の意図別相談CTAで個別対応する）
   'project-management': buildCta(FLOW_MAPPER, SCOPE_MANAGER),
-  // 見積もり懸念: スコープから概算 → ゼロスタート相談
-  'estimate-concerns': buildCta(SCOPE_MANAGER, STORY_BUILDER),
+  // 見積もりの不安: 純買い手カテゴリ。費用相談を主、資料DLを副に
+  'estimate-concerns': buildCta(ESTIMATE_CONSULT, DOWNLOAD_DECK),
   // コミュニケーション: ストーリー → スコープ整理
   communication: buildCta(STORY_BUILDER, SCOPE_MANAGER),
-  // 要件定義: ストーリー → スコープ
-  'requirements-definition': buildCta(STORY_BUILDER, SCOPE_MANAGER),
-  // 業務改善・DX: 業務フロー → ストーリー
-  'business-improvement': buildCta(FLOW_MAPPER, STORY_BUILDER),
   // AI受託: 業務フロー → スコープ
   'ai-development': buildCta(FLOW_MAPPER, SCOPE_MANAGER),
-  // CDP: 業務フロー → スコープ
-  cdp: buildCta(FLOW_MAPPER, SCOPE_MANAGER),
+  // CDP(顧客データ基盤): 買い手の比較・選定が中心。CDP相談を主、資料DLを副に
+  // （旧 'cdp' キーは実カテゴリ ID 'cdp-development' と不一致で死んでいた）
+  'cdp-development': buildCta(CDP_CONSULT, DOWNLOAD_DECK),
   // DX・AI導入: BPO見直し → 要件のたたき台
   dx: buildCta(FLOW_MAPPER, STORY_BUILDER),
 };

--- a/src/lib/column-visuals.ts
+++ b/src/lib/column-visuals.ts
@@ -555,6 +555,48 @@ function buildZeroStartConsultCta(source: string, intent: string): string {
 </figure>`;
 }
 
+// AI検索が買い手を送り込む記事（見積・RFP・CDP比較・要件定義）向けの、意図別リード獲得CTA。
+// クエリ意図に文言を合わせ、ツールでなく相談（/contact）へ誘導する。
+type ConsultCta = { intent: string; title: string; body: string; label: string };
+
+const CONSULT_CTAS: Record<string, ConsultCta> = {
+  ESTIMATE_CONSULT: {
+    intent: 'estimate',
+    title: '開発費用の概算を無料で相談する',
+    body: '概算でも費用感を早く知りたい場合は、作りたいものの要件と規模感をお送りいただければ、費用レンジと内訳の考え方を無料でご返信します。見積書だけでは分かりにくい「どこにいくらかかるか」を、発注前に把握できます。',
+    label: '開発費用を相談する',
+  },
+  RFP_CONSULT: {
+    intent: 'rfp',
+    title: 'RFPの作成・見直しを相談する',
+    body: 'RFP（提案依頼書）の作成や見直しは、Beekleが代行した実績があります（製造業のDXプロジェクトで、補助金申請の要件としてRFP作成を代行）。RFPの書き方や外注先の選定でお困りなら、無料でご相談いただけます。',
+    label: 'RFP作成を相談する',
+  },
+  CDP_CONSULT: {
+    intent: 'cdp',
+    title: '自社に合うCDPを相談する',
+    body: 'どのCDPが自社に合うか、比較段階での疑問は無料でご相談いただけます。要件をお聞きしたうえで、既製CDP（Treasure Data・Salesforce CDP 等）と自社開発（BigQuery 等）の判断軸まで整理してお返しします。',
+    label: 'CDP選定を相談する',
+  },
+  REQ_CONSULT: {
+    intent: 'requirements',
+    title: '要件定義を一緒に詰める',
+    body: '要件定義の進め方やドキュメントの書き方で迷ったら、実際のプロジェクトに即して一緒に詰めるご相談も承っています。発注側の判断材料が揃うように伴走します。',
+    label: '要件定義を相談する',
+  },
+};
+
+function buildConsultCta(source: string, cta: ConsultCta): string {
+  const href = `/contact?source=${encodeURIComponent(source)}&intent=${encodeURIComponent(cta.intent)}`;
+  return `<figure class="cv-card">
+  <figcaption class="cv-card-header cv-header-primary">${cta.title}</figcaption>
+  <div class="cv-card-body">
+    <p>${cta.body}</p>
+    <p style="text-align:center;margin-top:1.25rem;"><a href="${href}" data-cta-source="${source}" data-cta-id="contact-${cta.intent}">${cta.label}</a></p>
+  </div>
+</figure>`;
+}
+
 const EARS_GHERKIN_WORKFLOW = `<figure class="cv-whyhow">
   <figcaption class="cv-whyhow-title">ビジネスサイド → エンジニア → デモ／テストの流れ</figcaption>
   <div class="cv-whyhow-box cv-whyhow-why">
@@ -660,6 +702,14 @@ export function renderColumnVisuals(html: string, ctx?: ColumnVisualContext): st
     const bridgeMarkers: Array<[string, string]> = [['BRIDGE_CTA', 'bridge']];
     for (const [key, _intent] of bridgeMarkers) {
       const visual = buildBridgeCta(ctx.source);
+      const wrapped = new RegExp(`<p>\\s*\\{\\{${key}\\}\\}\\s*</p>`, 'g');
+      const bare = new RegExp(`\\{\\{${key}\\}\\}`, 'g');
+      result = result.replace(wrapped, visual).replace(bare, visual);
+    }
+
+    // 意図別の相談CTA（見積・RFP・CDP・要件定義）
+    for (const [key, cta] of Object.entries(CONSULT_CTAS)) {
+      const visual = buildConsultCta(ctx.source, cta);
       const wrapped = new RegExp(`<p>\\s*\\{\\{${key}\\}\\}\\s*</p>`, 'g');
       const bare = new RegExp(`\\{\\{${key}\\}\\}`, 'g');
       result = result.replace(wrapped, visual).replace(bare, visual);


### PR DESCRIPTION
## 背景
AI Citations 分析（`docs/marketing/ai-citation-analysis-2026-06-19.md`）で、AIが見積・RFP・CDP比較・要件定義の発注者を特定ページに送り込んでいると判明。これらの買い手ページの主動線がツール誘導になっていたため、リード獲得（相談・資料DL）に切り替える。

## 変更
- `column-cta-mapping.ts`: `estimate-concerns`→費用相談+資料DL、`cdp-development`→CDP相談+資料DL（旧 'cdp' キーの取りこぼしも修正）
- `column-visuals.ts`: 意図別相談CTA `{{ESTIMATE_CONSULT}}` `{{RFP_CONSULT}}` `{{CDP_CONSULT}}` `{{REQ_CONSULT}}` を追加（`/contact?intent=...`、pill化対応）
- `scripts/patch-buyer-consult-cta.mjs`: 7ページにマーカー挿入（MicroCMS、適用済み・冪等）

## ⚠️ デプロイ順序の注意
MicroCMS のマーカー挿入は**既に本番反映済み**。レンダリング側の本コードがマージ・デプロイされるまで、対象7ページにリテラル `{{...}}` が表示される。**早急にマージが必要**。

## 検証
- dev 実機で全7ページのCTA描画・リテラル残存なし・pill化・カテゴリCTA切替を確認
- `bun run build` 成功 / Biome クリーン