### PR TITLE
feat(contact): 問い合わせをHubSpot CRMに自動登録

### DIFF
--- a/.claude/rules/hubspot-crm.md
+++ b/.claude/rules/hubspot-crm.md
@@ -18,19 +18,40 @@
 
 ## env（Cloudflare Pages secret / plain）
 
-- `HUBSPOT_ACCESS_TOKEN`（secret, 必須）— Private App トークン。未設定なら同期スキップ。
-- `HUBSPOT_DEAL_PIPELINE`（plain, optional）— 既定 `default`
-- `HUBSPOT_DEAL_STAGE`（plain, optional）— 既定 `appointmentscheduled`（無料プランのデフォルト営業パイプライン初期ステージ）
+- `HUBSPOT_ACCESS_TOKEN`（secret, 必須）— Service Key（または legacy Private App）トークン。未設定なら同期スキップ。
+- `HUBSPOT_DEAL_PIPELINE`（optional）— 既定 `default`
+- `HUBSPOT_DEAL_STAGE`（**実質必須**）— コード既定は `appointmentscheduled` だが、これは下記の本番ポータルには存在しない。
 
-`default` / `appointmentscheduled` は HubSpot 無料プランのデフォルト営業パイプラインの想定値。**実アカウントでパイプライン/ステージ ID が違うと Deal 作成が 400 になる**ので、トークン投入後に最初の1件で Deal が出来ているか確認し、違えば env で上書きする。ID は HubSpot の Settings → Objects → Deals → Pipelines、または `GET /crm/v3/pipelines/deals` で確認できる。
+### 本番ポータルの実測値（2026-06-24 検証済み, portalId=246584394）
+
+このアカウントの `default`（"Sales Pipeline"）はカスタム済みで、ステージが**数値ID**。`appointmentscheduled` というラベルIDは存在せず Deal 作成が 400（`INVALID_OPTION`）になる。実際のステージ:
+
+| order | stage ID | label |
+|---|---|---|
+| 0 | **3890223806** | Initial Consultation（= 新規問い合わせの入口。これを使う） |
+| 1 | 3890223807 | Prototype Creation |
+| 2 | 3890223808 | Prototype Review |
+| 3 | 3890223809 | Proposal & Negotiation |
+| 4 | closedwon | Closed Won |
+| 5 | closedlost | Closed Lost |
+
+→ `HUBSPOT_DEAL_PIPELINE=default` / `HUBSPOT_DEAL_STAGE=3890223806` を Cloudflare Pages（production + preview）と `.env` に設定済み。**コード既定のままだと Contact だけ作られ Deal は静かに 400 で落ちる**（`ok:true` なので気づきにくい）。
+
+ステージIDは `GET /crm/v3/pipelines/deals`（要 `crm.objects.deals.read` 等のスコープ。`bun run --env-file=.env` でトークンをロードして叩くのが手早い）か HubSpot の Settings → Objects → Deals → Pipelines で確認できる。パイプラインを編集すると ID が変わり得るので、400 が出たら再取得して env を更新する。
 
 ## セットアップ手順
 
 1. HubSpot **無料**アカウント作成（hubspot.com の「Get started free」。`Start free trial` の有料 Hub トライアルではない）
-2. Settings → Integrations → Private Apps → Create で Private App 作成。スコープ:
+2. **Service Key を発行する**（2026〜 推奨。旧「Private App」は legacy app 化し新規用途では非推奨）。
+   左サイドバー **Development → Keys → Service keys**（または Settings → Integrations → Service Keys）→ **Create service key** → 名前を付けて以下スコープを追加:
    - `crm.objects.contacts.read` / `crm.objects.contacts.write`
    - `crm.objects.deals.read` / `crm.objects.deals.write`
-3. 発行トークンを Cloudflare Pages に投入:
+
+   発行キーは `pat-na1-...` 形式で、Bearer トークンとしてそのまま `HUBSPOT_ACCESS_TOKEN` に入る（`src/lib/hubspot.ts` は `Authorization: Bearer ${token}` で叩くだけなのでコード変更不要）。Service Key の利点: 無停止ローテーション / 監査ログ / アカウントレベル（個人退職に影響されない）。
+   - **制約**: Service Key は **Webhook 非対応**。現状の push（Contact + Deal 作成）には影響しないが、下記「後々の ERP 連携」の Webhook 受信をやる時は project-based app（HubSpot CLI）か legacy private app が別途必要。
+   - 公式: https://developers.hubspot.com/blog/hubspot-service-keys-the-right-api-credential-for-data-integrations / https://developers.hubspot.com/docs/apps/developer-platform/build-apps/authentication/account-service-keys （2026-06 時点 public beta）
+   - 旧 Private App でも当面は動く（Settings → Integrations → Private Apps、legacy 表示）。既存トークンがあるならそのまま流用可。
+3. 発行トークン（Service Key）を Cloudflare Pages に投入:
    ```bash
    export CLOUDFLARE_API_TOKEN=$(cat .cloudflare/api-token)
    export CLOUDFLARE_ACCOUNT_ID=163fc8ca531cbe925ad7597ee0196f3a

--- a/.claude/rules/hubspot-crm.md
+++ b/.claude/rules/hubspot-crm.md
@@ -1,0 +1,54 @@
+# HubSpot CRM 連携（問い合わせ → Contact + Deal 自動登録）
+
+問い合わせ（`/api/contact`）を Slack 通知と並べて HubSpot CRM に自動登録する。営業の段階管理・履歴を HubSpot に寄せ、Slack は通知＋社内オペ（段階更新・タスク）に使う。後々の自作 ERP は HubSpot の CRM API / Webhook から経営数字を読む想定。
+
+## 実装
+
+- `src/lib/hubspot.ts`: `syncLeadToHubSpot(token, lead, env)`。raw fetch（依存ゼロ）、標準プロパティのみで HubSpot 側の事前カスタム設定不要。
+  - Contact を email idProperty で upsert（PATCH → 404 なら POST）
+  - Deal を作成し Contact に関連付け（`HUBSPOT_DEFINED` `associationTypeId: 3` = deal_to_contact）
+  - 流入アトリビューション（source/intent/phase/着地/参照元/UTM/GA cid）と本文・種別を Deal の `description` に格納
+- `src/pages/api/contact.ts`: Slack 送信成功後にベストエフォートで同期。`HUBSPOT_ACCESS_TOKEN` 未設定なら丸ごとスキップ。`runtime.ctx.waitUntil` があればバックグラウンド実行、無ければ await。
+
+## 設計上の鉄則（単一障害点を作らない）
+
+- HubSpot が落ちても問い合わせ（= Slack 通知）は**必ず成功させる**。`syncLeadToHubSpot` は throw せず結果オブジェクトを返し、呼び出し側も `.catch` で握る。
+- これは `incident-2026-05-06-slack-webhook-missing.md` の「通知を外部依存にしない」教訓と同じ。CRM 同期は通知のクリティカルパスに入れない。
+- Contact だけ成功して Deal が失敗（パイプライン/ステージ ID 不一致など）した場合も `ok: true` 扱いで Deal 失敗のみログ。
+
+## env（Cloudflare Pages secret / plain）
+
+- `HUBSPOT_ACCESS_TOKEN`（secret, 必須）— Private App トークン。未設定なら同期スキップ。
+- `HUBSPOT_DEAL_PIPELINE`（plain, optional）— 既定 `default`
+- `HUBSPOT_DEAL_STAGE`（plain, optional）— 既定 `appointmentscheduled`（無料プランのデフォルト営業パイプライン初期ステージ）
+
+`default` / `appointmentscheduled` は HubSpot 無料プランのデフォルト営業パイプラインの想定値。**実アカウントでパイプライン/ステージ ID が違うと Deal 作成が 400 になる**ので、トークン投入後に最初の1件で Deal が出来ているか確認し、違えば env で上書きする。ID は HubSpot の Settings → Objects → Deals → Pipelines、または `GET /crm/v3/pipelines/deals` で確認できる。
+
+## セットアップ手順
+
+1. HubSpot **無料**アカウント作成（hubspot.com の「Get started free」。`Start free trial` の有料 Hub トライアルではない）
+2. Settings → Integrations → Private Apps → Create で Private App 作成。スコープ:
+   - `crm.objects.contacts.read` / `crm.objects.contacts.write`
+   - `crm.objects.deals.read` / `crm.objects.deals.write`
+3. 発行トークンを Cloudflare Pages に投入:
+   ```bash
+   export CLOUDFLARE_API_TOKEN=$(cat .cloudflare/api-token)
+   export CLOUDFLARE_ACCOUNT_ID=163fc8ca531cbe925ad7597ee0196f3a
+   echo "<token>" | bunx wrangler pages secret put HUBSPOT_ACCESS_TOKEN --project-name website
+   echo "<token>" | bunx wrangler pages secret put HUBSPOT_ACCESS_TOKEN --project-name website --env preview
+   ```
+4. ローカル検証は `.dev.vars` に `HUBSPOT_ACCESS_TOKEN=...` を置く
+5. HubSpot の Slack アプリ（Marketplace）を接続 → 通知チャンネル設定、Slack から段階更新・メモ・タスク化
+
+## 後々の ERP 連携
+
+- Pull: `GET /crm/v3/objects/deals`（amount / dealstage / closedate）を定期取得して経営数字を集計。無料プランで Private App トークン利用可、レート上限 25万 req/日。
+- Push: Webhook で deal の段階変化をリアルタイム受信（1アプリ1000サブスクまで）。
+- ロックイン回避したいなら `/api/contact` で自前ストアにも二重書き込みする拡張余地あり（現状は未実装、HubSpot を正とする）。
+
+## 検証手順（トークン投入後）
+
+1. `/contact` か `/downloads/zero-start` からテスト送信
+2. HubSpot の Contacts に email で登録されているか、Deals に「Web問い合わせ: …」が出来て Contact に紐づいているか
+3. Deal が出来ていなければ Cloudflare のログで `[hubspot] deal create failed` を確認 → パイプライン/ステージ ID を env で修正
+4. Slack 通知は従来どおり届くこと（HubSpot 有無に関わらず）

--- a/.claude/rules/hubspot-crm.md
+++ b/.claude/rules/hubspot-crm.md
@@ -2,6 +2,19 @@
 
 問い合わせ（`/api/contact`）を Slack 通知と並べて HubSpot CRM に自動登録する。営業の段階管理・履歴を HubSpot に寄せ、Slack は通知＋社内オペ（段階更新・タスク）に使う。後々の自作 ERP は HubSpot の CRM API / Webhook から経営数字を読む想定。
 
+## Slack 連携の重要な制約（2026-06-24 検証）
+
+- **「Slack から顧客に返信」はメール/フォームチャネルでは HubSpot 非対応**。Slack 返信が効くのは **ライブチャット / WhatsApp / Facebook Messenger** のみ（[HubSpot公式](https://knowledge.hubspot.com/integrations/how-do-i-use-the-slack-integration)）。Web フォーム経由のリードを Inbox に入れても Slack からは返信できない。
+- 今 Slack に届いている通知は **`/api/contact` の直 incoming webhook**（HubSpot 経由ではない）。HubSpot は CRM 登録のみで、Inbox 会話は作らないので HubSpot→Slack は流れない。
+- **決定: Slack双方向は「ライブチャット」で実現する**（ユーザー選択 2026-06-24）。サイトに HubSpot トラッキングコードを入れてチャットウィジェットを表示 → 会話が Inbox に入る → Inbox⇄Slack 連携 → Slack から返信が顧客に届く。フォーム + CRM 同期は並存。
+  - 実装: `src/components/analytics/hubspot-chat.astro`（Clarity と同じく本番ホスト `beekle.jp` のみ起動）。ローダーは **na2 リージョン**なので `https://js-na2.hs-scripts.com/246584394.js`（`js.hs-scripts.com` だと 307 で na2 へリダイレクト）。`layout.astro` head に組み込み済み。
+  - **コード設置だけではチャットは出ない**。HubSpot 側で chatflow を作成・公開し、対象URLにターゲティング＋Inbox接続が必要。さらに Inbox⇄Slack 連携（ユーザーマッピング、対象チャンネルに HubSpot アプリを招待）。
+  - 注: HubSpot トラッキングコードは Cookie を置く。`/privacy` に追記が必要（未対応）。
+
+## アカウント情報（2026-06-24 確認）
+
+- HubSpot ポータル **portalId 246584394**、リージョン **na2**（UI は `app-na2.hubspot.com`、トークンは `pat-na2-...`）。複数アカウントに所属していると `app.hubspot.com`(na1) を見て「レコードが無い」と誤認するので注意。Contact/Deal 直リンクは `https://app-na2.hubspot.com/contacts/246584394/record/0-1/<id>`（deal は `0-3`）。
+
 ## 実装
 
 - `src/lib/hubspot.ts`: `syncLeadToHubSpot(token, lead, env)`。raw fetch（依存ゼロ）、標準プロパティのみで HubSpot 側の事前カスタム設定不要。

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,48 @@
-SLACK_WEBHOOK_URL=your_slack_webhook_url_here
-# MicroCMS
+# MicroCMS (コラム/カテゴリ等のCMS)
 MICROCMS_SERVICE_DOMAIN=your_service_domain
 MICROCMS_API_KEY=your_api_key_here
-# Google Analytics 4
+
+# Slack (問い合わせ・資料DL通知。/api/contact が必須とする)
+SLACK_WEBHOOK_URL=your_slack_webhook_url_here
+
+# Google Analytics 4 (公開測定ID)
 PUBLIC_GA_MEASUREMENT_ID=G-R7BXGC7XN6
 
+# Cloudflare Turnstile (フォーム/AIデモのbot対策)
+TURNSTILE_SECRET_KEY=your_turnstile_secret_key   # secret: siteverify用
+TURNSTILE_SITE_KEY=your_turnstile_site_key       # plain: HTMLに埋め込む公開sitekey
+
+# OpenRouter (チャット/OCR/ヒアリング用LLM、description自動生成)
+OPENROUTER_API_KEY=your_openrouter_api_key
+# 以下は任意のモデル上書き（未設定ならコード側デフォルト）
+OPENROUTER_MODEL_CHAT=
+OPENROUTER_MODEL_OCR=
+OPENROUTER_MODEL_HEARING=openai/gpt-4o-mini
+
+# AI デモ制御
+AI_TURNSTILE_BYPASS=               # 'true' でTurnstile検証skip。ローカル/CI限定、本番には絶対設定しない
+AI_MONTHLY_BUDGET_USD=10           # 月次予算上限（kill-switch）
+AI_TIMEOUT_MS=                     # AI binding経路のタイムアウト(ms)。未設定ならコード側デフォルト
+
+# HubSpot CRM (問い合わせ → Contact + Deal 自動登録)
+# 未設定なら同期スキップ（問い合わせ/Slack通知は影響なし）
+# Service Key (Development → Keys → Service keys) を発行して入れる。形式は pat-na1-...
+# scope: crm.objects.contacts.read/write, crm.objects.deals.read/write
+HUBSPOT_ACCESS_TOKEN=pat-na1-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx   # secret
+# Deal を作る営業パイプライン/初期ステージ。
+# ステージIDはポータル固有。`GET /crm/v3/pipelines/deals` で確認すること。
+# このポータル(default=Sales Pipeline)の入口は 3890223806 (Initial Consultation)。
+# コード既定の appointmentscheduled はこのポータルに存在せず Deal作成が400になる（hubspot-crm.md参照）。
+HUBSPOT_DEAL_PIPELINE=default
+HUBSPOT_DEAL_STAGE=3890223806
+
+# --- ローカル運用スクリプト用（アプリ実行時は不要） ---
+# Cloudflare CLI/Workers AI (embed:columns 等)。通常は .cloudflare/api-token から自動export
+CLOUDFLARE_API_TOKEN=your_cloudflare_api_token
+CLOUDFLARE_ACCOUNT_ID=163fc8ca531cbe925ad7597ee0196f3a
+# Rakko キーワードAPI (scripts/MCP)
+RAKKO_API_KEY=your_rakko_api_key
+# Microsoft Clarity Data Export API (注: env名のtypoはこのまま運用)
+MICROSODT_CLARITY_API_KEY=your_clarity_api_key
+
+# 注: Workers AI binding (AI) と KV binding (RATE_LIMIT) は wrangler.toml で宣言する。.env には書かない。

--- a/src/components/analytics/hubspot-chat.astro
+++ b/src/components/analytics/hubspot-chat.astro
@@ -1,0 +1,24 @@
+---
+// HubSpot トラッキングコード（ライブチャット ウィジェット）。
+// 訪問者のチャットを HubSpot Conversations Inbox に会話スレッドとして取り込み、
+// Inbox⇄Slack 連携で「Slack から顧客返信」を成立させるための土台。
+// （Web フォーム経由のリードは Slack からの返信が HubSpot 非対応のため、双方向に
+//  したい接点はチャットに寄せる。フォーム + /api/contact の CRM 同期はそのまま並存。）
+//
+// 本番ドメイン (beekle.jp / www.beekle.jp) でのみ起動し、dev・preview(*.pages.dev) では
+// チャットも HubSpot Cookie も出さない（Clarity と同じ方針）。
+// Portal 246584394 / リージョン na2 → ローダーは js-na2.hs-scripts.com。
+const HUBSPOT_PORTAL_ID = '246584394';
+---
+
+<script is:inline define:vars={{ HUBSPOT_PORTAL_ID }}>
+  if (/(^|\.)beekle\.jp$/.test(location.hostname)) {
+    var s = document.createElement('script');
+    s.type = 'text/javascript';
+    s.id = 'hs-script-loader';
+    s.async = true;
+    s.defer = true;
+    s.src = 'https://js-na2.hs-scripts.com/' + HUBSPOT_PORTAL_ID + '.js';
+    document.head.appendChild(s);
+  }
+</script>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -2,6 +2,7 @@
 // src/layouts/layout.astro
 import Clarity from '../components/analytics/clarity.astro';
 import GA4 from '../components/analytics/ga4.astro';
+import HubSpotChat from '../components/analytics/hubspot-chat.astro';
 import JsonLd from '../components/seo/json-ld.astro';
 import SeoHead from '../components/seo/seo-head.astro';
 
@@ -41,6 +42,7 @@ const fullTitle = title.includes('Beekle') ? title : `${title} | Beekle`;
     <JsonLd type="organization" />
     <GA4 />
     <Clarity />
+    <HubSpotChat />
     <slot name="head" />
   </head>
   <body class="font-sans">

--- a/src/lib/hubspot.ts
+++ b/src/lib/hubspot.ts
@@ -10,7 +10,9 @@ const REQUEST_TIMEOUT_MS = 6000;
 
 export type HubSpotEnv = {
   HUBSPOT_ACCESS_TOKEN?: string;
-  // 既定の営業パイプライン / 初期ステージ。無料プランのデフォルトに合わせてある。
+  // 営業パイプライン / ステージ ID。未指定なら送らず、HubSpot のデフォルト
+  // パイプライン初期ステージに任せる（固定ラベルを送って 400 になるのを防ぐ）。
+  // 特定ステージに入れたい時だけ指定する。ID は GET /crm/v3/pipelines/deals で確認。
   HUBSPOT_DEAL_PIPELINE?: string;
   HUBSPOT_DEAL_STAGE?: string;
 };
@@ -117,10 +119,15 @@ async function createDeal(
 ): Promise<string> {
   const properties: Record<string, string> = {
     dealname: `Web問い合わせ: ${lead.name || lead.email}`,
-    pipeline: env.HUBSPOT_DEAL_PIPELINE || 'default',
-    dealstage: env.HUBSPOT_DEAL_STAGE || 'appointmentscheduled',
     description: buildDealDescription(lead),
   };
+  // pipeline / dealstage は env で明示された時だけ送る。
+  // 未指定で固定ラベル（旧: 'appointmentscheduled'）を送ると、ポータルが
+  // カスタムパイプライン（数値ステージID）の場合に存在しない値となり
+  // Deal 作成が 400 INVALID_OPTION になる。送らなければ HubSpot が
+  // デフォルトパイプラインの初期ステージへ自動配置する。
+  if (env.HUBSPOT_DEAL_PIPELINE) properties.pipeline = env.HUBSPOT_DEAL_PIPELINE;
+  if (env.HUBSPOT_DEAL_STAGE) properties.dealstage = env.HUBSPOT_DEAL_STAGE;
 
   const res = await hubspotFetch(token, '/crm/v3/objects/deals', 'POST', {
     properties,

--- a/src/lib/hubspot.ts
+++ b/src/lib/hubspot.ts
@@ -1,0 +1,167 @@
+// HubSpot CRM へのリード同期（ベストエフォート）。
+// /api/contact から Slack 通知と並べて呼び出す。HubSpot 側が落ちても
+// 問い合わせ自体は失敗させない（呼び出し側で waitUntil / catch する前提）。
+//
+// 依存ゼロ（raw fetch）。標準プロパティのみ使うので HubSpot 側の事前設定は不要。
+// 後々 ERP 連携する時は、ここで作られた Contact / Deal を CRM API か Webhook で読む。
+
+const HUBSPOT_BASE = 'https://api.hubapi.com';
+const REQUEST_TIMEOUT_MS = 6000;
+
+export type HubSpotEnv = {
+  HUBSPOT_ACCESS_TOKEN?: string;
+  // 既定の営業パイプライン / 初期ステージ。無料プランのデフォルトに合わせてある。
+  HUBSPOT_DEAL_PIPELINE?: string;
+  HUBSPOT_DEAL_STAGE?: string;
+};
+
+export type HubSpotLead = {
+  email: string;
+  name?: string;
+  company?: string;
+  phone?: string;
+  message: string;
+  typeLabel?: string;
+  source?: string;
+  intent?: string;
+  phase?: string;
+  landingPage?: string;
+  referrer?: string;
+  utm?: string;
+  clientId?: string;
+};
+
+type HubSpotResult = { ok: boolean; contactId?: string; dealId?: string; detail?: string };
+
+async function hubspotFetch(
+  token: string,
+  path: string,
+  method: string,
+  body: unknown
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(`${HUBSPOT_BASE}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: body == null ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// email を idProperty にして upsert する。存在すれば PATCH、無ければ POST で作成。
+async function upsertContact(token: string, lead: HubSpotLead): Promise<string> {
+  const properties: Record<string, string> = { email: lead.email };
+  if (lead.name) properties.firstname = lead.name;
+  if (lead.phone) properties.phone = lead.phone;
+  if (lead.company) properties.company = lead.company;
+
+  const patch = await hubspotFetch(
+    token,
+    `/crm/v3/objects/contacts/${encodeURIComponent(lead.email)}?idProperty=email`,
+    'PATCH',
+    { properties }
+  );
+  if (patch.ok) {
+    const data = (await patch.json()) as { id: string };
+    return data.id;
+  }
+  if (patch.status !== 404) {
+    const text = await patch.text().catch(() => '');
+    throw new Error(`contact upsert ${patch.status}: ${text || 'no body'}`);
+  }
+
+  // 未存在 → 新規作成
+  const post = await hubspotFetch(token, '/crm/v3/objects/contacts', 'POST', { properties });
+  if (!post.ok) {
+    const text = await post.text().catch(() => '');
+    throw new Error(`contact create ${post.status}: ${text || 'no body'}`);
+  }
+  const data = (await post.json()) as { id: string };
+  return data.id;
+}
+
+function buildDealDescription(lead: HubSpotLead): string {
+  const attribution = [
+    lead.source ? `経由元: ${lead.source}` : '',
+    lead.intent ? `intent: ${lead.intent}` : '',
+    lead.phase ? `phase: ${lead.phase}` : '',
+    lead.landingPage ? `着地: ${lead.landingPage}` : '',
+    lead.referrer ? `参照元: ${lead.referrer}` : '',
+    lead.utm ? `UTM: ${lead.utm}` : '',
+    lead.clientId ? `GA cid: ${lead.clientId}` : '',
+  ].filter(Boolean);
+
+  const sections = [
+    lead.typeLabel ? `種別: ${lead.typeLabel}` : '',
+    lead.message,
+    attribution.length > 0 ? ['--- 流入 ---', ...attribution].join('\n') : '',
+  ].filter(Boolean);
+
+  return sections.join('\n\n');
+}
+
+// Deal を作成し、同時に Contact へ関連付ける（HUBSPOT_DEFINED deal_to_contact = 3）。
+async function createDeal(
+  token: string,
+  contactId: string,
+  lead: HubSpotLead,
+  env: HubSpotEnv
+): Promise<string> {
+  const properties: Record<string, string> = {
+    dealname: `Web問い合わせ: ${lead.name || lead.email}`,
+    pipeline: env.HUBSPOT_DEAL_PIPELINE || 'default',
+    dealstage: env.HUBSPOT_DEAL_STAGE || 'appointmentscheduled',
+    description: buildDealDescription(lead),
+  };
+
+  const res = await hubspotFetch(token, '/crm/v3/objects/deals', 'POST', {
+    properties,
+    associations: [
+      {
+        to: { id: contactId },
+        types: [{ associationCategory: 'HUBSPOT_DEFINED', associationTypeId: 3 }],
+      },
+    ],
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`deal create ${res.status}: ${text || 'no body'}`);
+  }
+  const data = (await res.json()) as { id: string };
+  return data.id;
+}
+
+// 問い合わせを HubSpot に同期する。失敗しても throw せず結果オブジェクトで返す。
+export async function syncLeadToHubSpot(
+  token: string,
+  lead: HubSpotLead,
+  env: HubSpotEnv = {}
+): Promise<HubSpotResult> {
+  try {
+    const contactId = await upsertContact(token, lead);
+    let dealId: string | undefined;
+    try {
+      dealId = await createDeal(token, contactId, lead, env);
+    } catch (dealErr) {
+      // Contact は作れたが Deal 作成に失敗（パイプライン/ステージ ID 不一致など）。
+      // Contact 同期は成功扱いにして、Deal 失敗だけ記録する。
+      console.error(
+        '[hubspot] deal create failed:',
+        dealErr instanceof Error ? dealErr.message : dealErr
+      );
+    }
+    return { ok: true, contactId, dealId };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error('[hubspot] sync failed:', detail);
+    return { ok: false, detail };
+  }
+}

--- a/src/lib/hubspot.ts
+++ b/src/lib/hubspot.ts
@@ -10,9 +10,10 @@ const REQUEST_TIMEOUT_MS = 6000;
 
 export type HubSpotEnv = {
   HUBSPOT_ACCESS_TOKEN?: string;
-  // 営業パイプライン / ステージ ID。未指定なら送らず、HubSpot のデフォルト
-  // パイプライン初期ステージに任せる（固定ラベルを送って 400 になるのを防ぐ）。
-  // 特定ステージに入れたい時だけ指定する。ID は GET /crm/v3/pipelines/deals で確認。
+  // 営業パイプライン / ステージ ID。未指定なら送らない（固定ラベルを送って
+  // 400 になるのを防ぐ）。ただし未指定だと Deal は pipeline/dealstage = null で
+  // 保存され、ボード上で未配置になる。正しいステージに入れるには指定が必要。
+  // ID は GET /crm/v3/pipelines/deals で確認。
   HUBSPOT_DEAL_PIPELINE?: string;
   HUBSPOT_DEAL_STAGE?: string;
 };
@@ -124,8 +125,8 @@ async function createDeal(
   // pipeline / dealstage は env で明示された時だけ送る。
   // 未指定で固定ラベル（旧: 'appointmentscheduled'）を送ると、ポータルが
   // カスタムパイプライン（数値ステージID）の場合に存在しない値となり
-  // Deal 作成が 400 INVALID_OPTION になる。送らなければ HubSpot が
-  // デフォルトパイプラインの初期ステージへ自動配置する。
+  // Deal 作成が 400 INVALID_OPTION になる。送らなければ作成は通るが、
+  // pipeline/dealstage = null（未配置）で保存される（検証 2026-06-24）。
   if (env.HUBSPOT_DEAL_PIPELINE) properties.pipeline = env.HUBSPOT_DEAL_PIPELINE;
   if (env.HUBSPOT_DEAL_STAGE) properties.dealstage = env.HUBSPOT_DEAL_STAGE;
 

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { z } from 'zod';
 import { readSession } from '../../lib/flow-interview/session';
+import { syncLeadToHubSpot } from '../../lib/hubspot';
 import { verifyTurnstile } from '../../lib/turnstile';
 
 export const prerender = false;
@@ -78,7 +79,11 @@ export const POST: APIRoute = async ({ request, locals }) => {
             SLACK_WEBHOOK_URL?: string;
             TURNSTILE_SECRET_KEY?: string;
             RATE_LIMIT?: { get(key: string): Promise<string | null> };
+            HUBSPOT_ACCESS_TOKEN?: string;
+            HUBSPOT_DEAL_PIPELINE?: string;
+            HUBSPOT_DEAL_STAGE?: string;
           };
+          ctx?: { waitUntil?: (promise: Promise<unknown>) => void };
         };
       }
     ).runtime;
@@ -211,6 +216,43 @@ export const POST: APIRoute = async ({ request, locals }) => {
     };
 
     await postToSlack(webhookUrl, slackMessage);
+
+    // HubSpot CRM へベストエフォートで同期する。トークン未設定ならスキップ。
+    // HubSpot 側が落ちても問い合わせ（= Slack 通知）は成功させる。過去の
+    // SLACK_WEBHOOK_URL 単一障害点インシデントと同様、通知系を CRM に依存させない。
+    const hubspotToken = runtime?.env?.HUBSPOT_ACCESS_TOKEN;
+    if (hubspotToken) {
+      const syncTask = syncLeadToHubSpot(
+        hubspotToken,
+        {
+          email,
+          name,
+          company,
+          phone,
+          message,
+          typeLabel: TYPE_LABELS[typeStr] || typeStr,
+          source,
+          intent,
+          phase,
+          landingPage,
+          referrer,
+          utm: utmText,
+          clientId,
+        },
+        {
+          HUBSPOT_DEAL_PIPELINE: runtime?.env?.HUBSPOT_DEAL_PIPELINE,
+          HUBSPOT_DEAL_STAGE: runtime?.env?.HUBSPOT_DEAL_STAGE,
+        }
+      ).catch((err) => {
+        console.error('[contact] hubspot sync threw:', err instanceof Error ? err.message : err);
+      });
+
+      // レスポンスを遅らせないよう waitUntil でバックグラウンド実行。
+      // 無ければ（ローカル dev 等）応答前に await する。
+      const waitUntil = runtime?.ctx?.waitUntil;
+      if (waitUntil) waitUntil(syncTask);
+      else await syncTask;
+    }
 
     return new Response(JSON.stringify({ success: true }), {
       status: 200,


### PR DESCRIPTION
## 概要

問い合わせ（`/api/contact`）を Slack 通知と並べて HubSpot CRM に自動登録する。営業の段階管理・履歴を HubSpot に寄せ、Slack は通知＋社内オペに使う。

## 変更

- `src/lib/hubspot.ts`: `syncLeadToHubSpot()`。raw fetch・標準プロパティのみ（HubSpot側の事前設定不要）。Contact を email で upsert → Deal 作成 + 関連付け。流入アトリビューション（source/intent/phase/着地/参照元/UTM/GA cid）を Deal description に格納。
- `src/pages/api/contact.ts`: Slack 送信成功後に `waitUntil` でバックグラウンド同期。`HUBSPOT_ACCESS_TOKEN` 未設定ならスキップ。
- `.claude/rules/hubspot-crm.md`: セットアップ手順・ERP連携方針。

## 設計

- **単一障害点を作らない**: HubSpot が落ちても問い合わせ（Slack通知）は必ず成功。`syncLeadToHubSpot` は throw せず、呼び出し側も catch。incident-2026-05-06 の教訓に準拠。
- 新規依存なし（raw fetch）→ lockfile 同期不要。

## 有効化（マージだけでは動かない・トークン必須）

1. HubSpot 無料アカウント作成
2. Private App トークン発行（スコープ: contacts/deals read+write）
3. `wrangler pages secret put HUBSPOT_ACCESS_TOKEN`（production + preview）
4. HubSpot Slack アプリ接続

## 検証メモ

Deal の pipeline/stage は無料デフォルト（`default`/`appointmentscheduled`）を仮定。実アカウントで ID が違うと Deal 作成のみ 400（Contact は成功・ログに記録）。その場合 `HUBSPOT_DEAL_PIPELINE`/`HUBSPOT_DEAL_STAGE` env で上書き。トークン投入後に初回送信で要確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)